### PR TITLE
refactor: change tmux prefix shortcut

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -1,4 +1,3 @@
-set -g prefix C-j
 set -g escape-time 100
 
 set-option -g mouse on


### PR DESCRIPTION
Codexの改行コマンドがCtrl-jで現状はCodexの方で改行コマンドのショートカットを変更する設定がないのでtmux側の設定を変更