### PR TITLE
feat: split KubeVirt image into minimal base + in-VM rebuild

### DIFF
--- a/.config/claude/skills/ghcr-publish/SKILL.md
+++ b/.config/claude/skills/ghcr-publish/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: ghcr-publish
+description: Write GitHub Actions workflows that build Docker images and push them to GitHub Container Registry (ghcr.io). Use when a repository needs CI image publishing. Detects whether the repo is single-container (one Dockerfile at root) or multi-container (monorepo with multiple services), and generates one workflow per image with correct context, paths filter, and tags.
+---
+
+# GHCR Publish CI
+
+GitHub Actions workflow を書いて Docker イメージをビルドし GHCR に push する。
+
+## Workflow
+
+1. Dockerfile の場所を検出する:
+
+   ```bash
+   find . -name Dockerfile -not -path '*/node_modules/*' -not -path '*/.git/*'
+   ```
+
+2. パターンを選ぶ:
+   - Dockerfile がリポジトリルートに 1 つ → **単一コンテナパターン**（1 ファイル `.github/workflows/build-push.yml`）
+   - Dockerfile がサブディレクトリに複数 → **マルチコンテナパターン**（サービスごとに `.github/workflows/<service>-ci.yml` を作成）
+3. イメージ名を決める:
+   - 単一コンテナ: `ghcr.io/<owner>/<repo>`（またはアプリ固有の名前）
+   - マルチコンテナ: `ghcr.io/<owner>/<repo>-<service>`（例: `bbs-mcp-server`, `bbs-search-backend`）
+4. デフォルトブランチ名（`main` / `master`）がリポジトリと一致しているか確認する。
+5. マルチコンテナでは `paths` フィルタに **サービスのディレクトリと workflow ファイル自身** の両方を含める。
+6. 書き終えたら `pinact run` を実行して action の pin を解決する。
+
+## 共通の必須要素
+
+- `permissions`: `contents: read` と `packages: write`
+- `docker/setup-buildx-action@v3` で Buildx をセットアップ
+- `docker/login-action@v3`: `${{ github.actor }}` + `${{ secrets.GITHUB_TOKEN }}`
+- `docker/metadata-action@v5`: tags は `latest`（デフォルトブランチのみ）+ `sha` + git tag、labels に `org.opencontainers.image.source`
+- `docker/build-push-action@v6`: `push: true`, `platforms: linux/amd64`, GHA キャッシュ（`cache-from`/`cache-to: type=gha`）
+
+## Template: 単一コンテナ（例: currency-exchange-discord-bot）
+
+`.github/workflows/build-push.yml`:
+
+```yaml
+name: Build & Push to GHCR
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/<image-name>
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable=true
+            type=ref,event=tag
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+## Template: マルチコンテナ / monorepo（例: bbs）
+
+サービスごとに `.github/workflows/<service>-ci.yml` を 1 ファイルずつ作る:
+
+```yaml
+name: Build & Push to GHCR
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - <service-dir>/**
+      - .github/workflows/<service>-ci.yml
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/<repo>-<service>
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable=true
+            type=ref,event=tag
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          context: <service-dir>
+          file: <service-dir>/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+`<service-dir>` はネストしていてもよい（例: `search/backend` → イメージ名 `bbs-search-backend`、workflow 名 `search-backend-ci.yml`）。
+
+## Final Checks
+
+- `context` / `file` が検出した Dockerfile のパスと一致しているか。
+- マルチコンテナの場合、`paths` フィルタと workflow ファイル名がサービスごとに正しいか。
+- イメージ名が明示的で安定しているか。
+- `pinact run` を実行し、報告された問題を解決してから完了とする。

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ claude:
 	mkdir -p ${HOME}/.config/claude
 	ln -sf ${PWD}/.config/claude/settings.json ${HOME}/.config/claude
 	ln -sf ${PWD}/.config/claude/CLAUDE.md ${HOME}/.config/claude
+	ln -sfn ${PWD}/.config/claude/skills ${HOME}/.config/claude/skills
 
 codex:
 	mkdir -p ${HOME}/.codex

--- a/nix/README.md
+++ b/nix/README.md
@@ -46,6 +46,26 @@ nix flake update         # update all inputs in flake.lock
 nix flake update herdr   # update a single input
 ```
 
+### Dev VM on KubeVirt (zen2)
+
+The VM boots a minimal image (`.#kubevirt-image`, built from
+`nixosConfigurations.kubevirt-base`) that CDI imports from
+`gs://toof-infra-vm-images/nixos-dev.qcow2`; manifests live in
+toof-jp/infra `kubernetes/applications/dev-vm`. Apply the full dev config
+from inside the VM:
+
+```sh
+sudo nixos-rebuild switch --flake 'github:toof-jp/dotfiles?dir=nix#kubevirt'
+```
+
+To ship a new image:
+
+```sh
+nix build ./nix#kubevirt-image
+gcloud storage cp result/nixos.qcow2 gs://toof-infra-vm-images/nixos-dev.qcow2
+# then delete the dev-root DataVolume in the cluster to re-import
+```
+
 ## Notes
 
 - `claude-code` has an unfree license, so `allowUnfree = true` is set.

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -54,19 +54,28 @@
           modules = [ ./hosts/dev/configuration.nix ] ++ homeManagerModules;
         };
 
-        # Dev VM on KubeVirt (zen2)
+        # Dev VM on KubeVirt (zen2): full config, applied from inside the
+        # VM with nixos-rebuild (the shipped image only contains kubevirt-base)
         kubevirt = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           modules = [ ./hosts/kubevirt/configuration.nix ] ++ homeManagerModules;
         };
+
+        # What actually gets baked into the qcow2: boot + SSH only, so the
+        # slow cptofs step in the image build stays small
+        kubevirt-base = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ ./hosts/kubevirt/base.nix ];
+        };
       };
 
-      # qcow2 for the KubeVirt containerDisk:
+      # Minimal qcow2 for KubeVirt:
       #   nix build .#kubevirt-image
-      # 64 GiB virtual size (sparse, so the file only stores written data).
+      # 64 GiB virtual size (sparse), leaving room for the full config +
+      # dev work after the in-VM rebuild.
       packages.x86_64-linux.kubevirt-image =
         import (nixpkgs + "/nixos/lib/make-disk-image.nix") {
-          inherit (self.nixosConfigurations.kubevirt) config pkgs;
+          inherit (self.nixosConfigurations.kubevirt-base) config pkgs;
           lib = nixpkgs.lib;
           format = "qcow2";
           diskSize = 65536; # MiB

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -71,14 +71,17 @@
 
       # Minimal qcow2 for KubeVirt:
       #   nix build .#kubevirt-image
-      # 64 GiB virtual size (sparse), leaving room for the full config +
-      # dev work after the in-VM rebuild.
+      # Sized to the closure: large virtual sizes make cptofs OOM/thrash
+      # inside its 100MB LKL kernel. CDI expands the disk to the PVC size on
+      # import, and growPartition/autoResize (from the kubevirt module) grow
+      # the root fs on first boot.
       packages.x86_64-linux.kubevirt-image =
         import (nixpkgs + "/nixos/lib/make-disk-image.nix") {
           inherit (self.nixosConfigurations.kubevirt-base) config pkgs;
           lib = nixpkgs.lib;
           format = "qcow2";
-          diskSize = 65536; # MiB
+          diskSize = "auto";
+          additionalSpace = "2048M"; # slack until the first-boot resize
         };
 
       homeConfigurations = {

--- a/nix/hosts/kubevirt/base.nix
+++ b/nix/hosts/kubevirt/base.nix
@@ -1,0 +1,60 @@
+# Minimal KubeVirt image: just enough to boot, mount /home, and SSH in.
+# The image build time is dominated by cptofs copying the closure, so this
+# stays small; apply the full config from inside the VM afterwards:
+#
+#   sudo nixos-rebuild switch --flake 'github:toof-jp/dotfiles?dir=nix#kubevirt'
+#
+# The nixpkgs kubevirt module brings in: qemu-guest profile, serial console,
+# qemu-guest-agent, openssh, cloud-init.
+{ modulesPath, pkgs, ... }:
+
+{
+  imports = [ "${modulesPath}/virtualisation/kubevirt.nix" ];
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  networking.hostName = "dev-vm";
+  time.timeZone = "Asia/Tokyo";
+  i18n.defaultLocale = "en_US.UTF-8";
+
+  programs.zsh.enable = true;
+
+  users.users.toof = {
+    isNormalUser = true;
+    shell = pkgs.zsh;
+    extraGroups = [ "wheel" ];
+    # github.com/toof-jp.keys — also injected via cloud-init, but baked in
+    # so SSH works even if the datasource is missing
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIHWo3K3cd7yix7fvAkklAl11w+u0u+jYYgFcOsNBmpf"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILUJhZJJtxQQzpQN23OAInodVNC1VT2ZAWtsyH0bPpVM"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILVxr9QhV4fip8VAil6IZL+WsHtV55GJeD+yRw/8i/WO"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLZJDizwTJSPK1x4fO9GqrGVdTkG6s80UcX64vBlYDo"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJHEKg+P0OX5pUPHiWOjecgemiZDBRiMjejO/z+oTZQy"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFCD8d8Um1oUDliqkWvgdoOlgBU/+tjxl1GjkTgvSFPv"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDrgBC/but8okN4/yhtvHcnhQEJCbE/9qEfdaPt1M6C7"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIxEuii9kpBBeLSh31H8aROCRyJm1GeXtF3mXXZFzJYe"
+    ];
+  };
+  # containerDisk root is ephemeral; no local secrets to protect and the VM
+  # is only reachable inside the cluster
+  security.sudo.wheelNeedsPassword = false;
+
+  # /home lives on a Longhorn PVC (virtio disk with serial "home"),
+  # formatted on first boot so it survives VM restarts
+  fileSystems."/home" = {
+    device = "/dev/disk/by-id/virtio-home";
+    fsType = "ext4";
+    autoFormat = true;
+    autoResize = true;
+    options = [ "nofail" ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    git # needed for the flake rebuild
+    vim
+  ];
+
+  system.stateVersion = "25.11";
+}

--- a/nix/hosts/kubevirt/configuration.nix
+++ b/nix/hosts/kubevirt/configuration.nix
@@ -1,71 +1,28 @@
-# Dev VM running on KubeVirt (zen2). Built as a containerDisk qcow2.
-#
-# The nixpkgs kubevirt module brings in: qemu-guest profile, serial console,
-# qemu-guest-agent, openssh, cloud-init (SSH keys are injected by the
-# cloudInitNoCloud volume in the VirtualMachine manifest).
-{ modulesPath, pkgs, ... }:
+# Full dev VM config, applied from inside the VM (the shipped image only
+# contains base.nix — see the comment there).
+{ pkgs, ... }:
 
 {
-  imports = [ "${modulesPath}/virtualisation/kubevirt.nix" ];
+  imports = [ ./base.nix ];
 
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nixpkgs.config.allowUnfree = true;
+
   nix.gc = {
     automatic = true;
     dates = "weekly";
     options = "--delete-older-than 30d";
   };
 
-  nixpkgs.config.allowUnfree = true;
-
-  networking.hostName = "dev-vm";
-  time.timeZone = "Asia/Tokyo";
-  i18n.defaultLocale = "en_US.UTF-8";
-
-  programs.zsh.enable = true;
-
-  users.users.toof = {
-    isNormalUser = true;
-    shell = pkgs.zsh;
-    extraGroups = [ "wheel" "docker" ];
-    # github.com/toof-jp.keys — also injected via cloud-init, but baked in
-    # so SSH works even if the datasource is missing
-    openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIHWo3K3cd7yix7fvAkklAl11w+u0u+jYYgFcOsNBmpf"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILUJhZJJtxQQzpQN23OAInodVNC1VT2ZAWtsyH0bPpVM"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILVxr9QhV4fip8VAil6IZL+WsHtV55GJeD+yRw/8i/WO"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBLZJDizwTJSPK1x4fO9GqrGVdTkG6s80UcX64vBlYDo"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJHEKg+P0OX5pUPHiWOjecgemiZDBRiMjejO/z+oTZQy"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFCD8d8Um1oUDliqkWvgdoOlgBU/+tjxl1GjkTgvSFPv"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDrgBC/but8okN4/yhtvHcnhQEJCbE/9qEfdaPt1M6C7"
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIxEuii9kpBBeLSh31H8aROCRyJm1GeXtF3mXXZFzJYe"
-    ];
-  };
-  # containerDisk root is ephemeral; no local secrets to protect and the VM
-  # is only reachable inside the cluster
-  security.sudo.wheelNeedsPassword = false;
+  users.users.toof.extraGroups = [ "docker" ];
 
   virtualisation.docker = {
     enable = true;
+    # default docker 28.x is marked insecure in nixos-25.11
     package = pkgs.docker_29;
   };
 
-  # /home lives on a Longhorn PVC (virtio disk with serial "home"),
-  # formatted on first boot so it survives VM restarts
-  fileSystems."/home" = {
-    device = "/dev/disk/by-id/virtio-home";
-    fsType = "ext4";
-    autoFormat = true;
-    autoResize = true;
-    options = [ "nofail" ];
-  };
-
   environment.systemPackages = with pkgs; [
-    vim
-    git
     curl
     wget
   ];
-
-  system.stateVersion = "25.11";
 }


### PR DESCRIPTION
## Summary
- `.#kubevirt-image` now builds from new `nixosConfigurations.kubevirt-base` (boot + SSH + git only) instead of the full dev environment, cutting the slow cptofs step from hours to minutes
- The full config (`nixosConfigurations.kubevirt`: home-manager, docker, dev tools) is applied from inside the VM: `sudo nixos-rebuild switch --flake 'github:toof-jp/dotfiles?dir=nix#kubevirt'`
- README documents the image ship flow (build → `gcloud storage cp` → delete dev-root DataVolume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)