### PR TITLE
feat: bake /etc/nixos/flake.nix into the dev VM

### DIFF
--- a/nix/hosts/kubevirt/configuration.nix
+++ b/nix/hosts/kubevirt/configuration.nix
@@ -5,6 +5,19 @@
 {
   imports = [ ./base.nix ];
 
+  # Lets plain `sudo nixos-rebuild switch` work inside the VM (nixos-rebuild
+  # picks up /etc/nixos/flake.nix and the attr matching the hostname).
+  # Use `--refresh` to force-fetch the latest dotfiles; the github tarball
+  # is otherwise cached for a while.
+  environment.etc."nixos/flake.nix".text = ''
+    {
+      inputs.dotfiles.url = "github:toof-jp/dotfiles?dir=nix";
+      outputs = { dotfiles, ... }: {
+        nixosConfigurations.dev-vm = dotfiles.nixosConfigurations.kubevirt;
+      };
+    }
+  '';
+
   nixpkgs.config.allowUnfree = true;
 
   nix.gc = {


### PR DESCRIPTION
## Summary
Plain `sudo nixos-rebuild switch` inside the VM failed with *file 'nixos-config' was not found* because there is no `/etc/nixos`. This bakes a minimal `/etc/nixos/flake.nix` into the image config that re-exports `nixosConfigurations.kubevirt` from this repo under the VM's hostname (`dev-vm`), which nixos-rebuild picks up automatically.

Note: use `sudo nixos-rebuild switch --refresh` to force-fetch the latest dotfiles (the github tarball is cached for a while).

🤖 Generated with [Claude Code](https://claude.com/claude-code)