### PR TITLE
feat: add ShellCheck CI

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+name: ShellCheck
+
+# .zshrc is zsh, which ShellCheck does not support; only *.sh files
+# (POSIX/bash) are checked.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run ShellCheck
+        run: git ls-files '*.sh' | xargs -r shellcheck


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that runs `shellcheck` on all tracked `*.sh` files, on pushes to main and on PRs.
- Uses the runner's preinstalled shellcheck; checkout action pinned by SHA to match `vm-image.yml`.
- `.zshrc` is zsh, which ShellCheck does not support, so it is out of scope (the issue's idea of extracting POSIX parts of .zshrc can be a follow-up).
- `krew.sh` already passes locally.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)