### PR TITLE
feat: add git-gtr, gh-dash, and tailscale to nix

### DIFF
--- a/nix/home/git-gtr.nix
+++ b/nix/home/git-gtr.nix
@@ -1,0 +1,33 @@
+# git-worktree-runner (`git gtr`) — not in nixpkgs, so packaged here.
+# Pure bash; the scripts locate their lib/ relative to the resolved script
+# path, so the whole tree is installed and bin/ is symlinked.
+{ stdenvNoCC, fetchFromGitHub, bash }:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "git-worktree-runner";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "coderabbitai";
+    repo = "git-worktree-runner";
+    tag = "v${version}";
+    hash = "sha256-KZsAx80sScdH8AKCFgmQ6gdVViaN3h1VHiE/pSoCm8o=";
+  };
+
+  buildInputs = [ bash ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/git-worktree-runner $out/bin
+    cp -r bin lib adapters templates $out/share/git-worktree-runner/
+    ln -s $out/share/git-worktree-runner/bin/git-gtr $out/bin/git-gtr
+    ln -s $out/share/git-worktree-runner/bin/gtr $out/bin/gtr
+
+    install -Dm644 completions/_git-gtr $out/share/zsh/site-functions/_git-gtr
+
+    runHook postInstall
+  '';
+
+  meta.description = "Git worktree management (git gtr)";
+}

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -21,7 +21,9 @@
     # git
     git
     gh
+    gh-dash # wired as a gh extension below; alias dash='gh dash'
     ghq
+    (callPackage ./git-gtr.nix { }) # git gtr — worktree runner
     difftastic # git diff.external = difft
 
     # editor / terminal
@@ -53,4 +55,9 @@
   ] ++ lib.optionals pkgs.stdenv.isDarwin [
     pinentry_mac
   ];
+
+  # gh looks for extensions in ~/.local/share/gh/extensions, not on PATH;
+  # wire gh-dash there so `gh dash` works without `gh extension install`.
+  home.file.".local/share/gh/extensions/gh-dash/gh-dash".source =
+    "${pkgs.gh-dash}/bin/gh-dash";
 }

--- a/nix/hosts/dev/configuration.nix
+++ b/nix/hosts/dev/configuration.nix
@@ -44,6 +44,9 @@
   services.pcscd.enable = true;
   programs.gnupg.agent.enable = true;
 
+  # First time: sudo tailscale up
+  services.tailscale.enable = true;
+
   environment.systemPackages = with pkgs; [
     vim
     git

--- a/nix/hosts/kubevirt/configuration.nix
+++ b/nix/hosts/kubevirt/configuration.nix
@@ -28,6 +28,9 @@
 
   users.users.toof.extraGroups = [ "docker" ];
 
+  # First time: sudo tailscale up
+  services.tailscale.enable = true;
+
   virtualisation.docker = {
     enable = true;
     # default docker 28.x is marked insecure in nixos-25.11


### PR DESCRIPTION
## Summary
- **git-gtr**: `git-worktree-runner` is not in nixpkgs, so it's packaged in `nix/home/git-gtr.nix` from the upstream v2.8.0 tag (pure bash; whole tree installed, `bin/` symlinked, zsh completion included). `git gtr` / `gtr` land on PATH via home.packages.
- **gh-dash**: added from nixpkgs and symlinked into `~/.local/share/gh/extensions/gh-dash/gh-dash` — gh only discovers extensions there, not on PATH — so `gh dash` (alias `dash`) works without `gh extension install`.
- **tailscale**: enabled as `services.tailscale` on both NixOS hosts (dev, kubevirt). It needs the system daemon, so it's a host-level service rather than a home-manager package (non-NixOS machines keep installing it via their OS). First run: `sudo tailscale up`.

## Verification
- `nix build` of the git-gtr derivation succeeds; `git-gtr version` → 2.8.0, and `git gtr version` resolves via PATH.
- `toof@linux` home config and both `dev` / `kubevirt` NixOS toplevels evaluate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)