### PR TITLE
feat: reproduce lua-nvim config with nixvim

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,5 +1,44 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "herdr": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -40,6 +79,34 @@
         "type": "github"
       }
     },
+    "ixx": {
+      "inputs": {
+        "flake-utils": [
+          "nixvim",
+          "nuschtosSearch",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixvim",
+          "nuschtosSearch",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1754860581,
+        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
+        "owner": "NuschtOS",
+        "repo": "ixx",
+        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NuschtOS",
+        "ref": "v0.1.1",
+        "repo": "ixx",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779357205,
@@ -72,11 +139,59 @@
         "type": "github"
       }
     },
+    "nixvim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nuschtosSearch": "nuschtosSearch",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1780865908,
+        "narHash": "sha256-UMwL+pE2I49q6qOV8w6pnuF3utb1qQuofmprBAhOU6A=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "68e314303bc60b8a58cdd2f361013809620b2473",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "nixos-25.11",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "nuschtosSearch": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "ixx": "ixx",
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768249818,
+        "narHash": "sha256-ANfn5OqIxq3HONPIXZ6zuI5sLzX1sS+2qcf/Pa0kQEc=",
+        "owner": "NuschtOS",
+        "repo": "search",
+        "rev": "b6f77b88e9009bfde28e2130e218e5123dc66796",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NuschtOS",
+        "repo": "search",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "herdr": "herdr",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "nixvim": "nixvim"
       }
     },
     "rust-overlay": {
@@ -97,6 +212,36 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -9,6 +9,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nixvim = {
+      url = "github:nix-community/nixvim/nixos-25.11";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Upstream pins nixos-unstable + rust-overlay toolchain; intentionally
     # not following our nixpkgs so it builds exactly as upstream CI tests it.
     herdr.url = "github:ogulcancelik/herdr";

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -5,6 +5,8 @@
 { pkgs, lib, inputs, ... }:
 
 {
+  imports = [ ./nixvim.nix ];
+
   home.stateVersion = "25.11";
 
   programs.home-manager.enable = true;
@@ -25,7 +27,11 @@
     difftastic # git diff.external = difft
 
     # editor / terminal
-    neovim # .config/nvim, .config/lua-nvim
+    # Plain neovim stays for the NVIM_APPNAME-based configs (.config/nvim /
+    # .config/lua-nvim, aliases ov / v). nixvim (see ./nixvim.nix) also ships
+    # a bin/nvim; hiPrio lets this one win the `nvim` name, the nixvim build
+    # is available as `nixvim`.
+    (lib.hiPrio neovim)
     tmux # .config/tmux
 
     # kubernetes

--- a/nix/home/nixvim.nix
+++ b/nix/home/nixvim.nix
@@ -1,0 +1,173 @@
+# Nixvim port of .config/lua-nvim (the lazy.nvim based config).
+#
+# Parallel install: this module is added alongside the existing Makefile
+# symlinked configs (.config/nvim and .config/lua-nvim), which stay untouched.
+# Nixvim's wrapped neovim is launched with `-u <generated init>` so it ignores
+# NVIM_APPNAME configs; to keep the `ov` / `v` aliases working with the old
+# configs, home.nix keeps plain neovim with lib.hiPrio (it wins the `nvim`
+# name) and the nixvim build is exposed here as the `nixvim` command.
+#
+# Differences from .config/lua-nvim (intentional / unavoidable):
+#   - lazy.nvim itself is not used: nix takes over plugin management, so the
+#     bootstrap code in lua/config/lazy.lua has no equivalent.
+#   - noice.nvim was lazy-loaded on the VeryLazy event; here it loads at
+#     startup (nixvim does not lazy-load by default). Functionally identical.
+#   - lsp: `vim.lsp.enable("rust_analyzer")` relied on rust-analyzer from the
+#     environment (rustup). Here nvim-lspconfig still provides the default
+#     config and rust-analyzer is resolved from $PATH first, with the nixpkgs
+#     build appended as a fallback (packageFallback).
+{ inputs, pkgs, config, ... }:
+
+{
+  imports = [ inputs.nixvim.homeModules.nixvim ];
+
+  programs.nixvim = {
+    enable = true;
+
+    # In home-manager nixvim defaults to wrapRc = false, which writes its init
+    # to ~/.config/nvim via xdg.configFile — that would collide with the
+    # Makefile symlink ~/.config/nvim -> this repo. Bake the config into the
+    # wrapper (-u <generated init>) instead and keep the rtp pure so the
+    # symlinked configs are never picked up by this binary.
+    wrapRc = true;
+    impureRtp = false;
+
+    # lua/config/lazy.lua
+    globals = {
+      mapleader = " ";
+      maplocalleader = "\\";
+    };
+
+    # lua/core.lua + the opts set inside the statuscol plugin spec
+    opts = {
+      cursorline = true; # highlight cursor line
+      list = true; # show tabs and trailing spaces
+      clipboard = "unnamedplus"; # sync clipboard (provider comes from the environment)
+      expandtab = true; # insert spaces instead of tabs
+      tabstop = 2; # render a tab as two spaces
+      shiftwidth = 2; # use two spaces for auto indent
+      number = true;
+      relativenumber = true;
+    };
+
+    keymaps = [
+      {
+        mode = "x";
+        key = "p";
+        action = ''"_dP'';
+        options.desc = "paste in visual mode without yanking selection";
+      }
+      {
+        mode = "t";
+        key = "<Esc>";
+        action = "<C-\\><C-n>";
+        options = {
+          silent = true;
+          desc = "exit terminal-mode with Esc";
+        };
+      }
+      {
+        mode = "n";
+        key = "Q";
+        action.__raw = ''
+          function()
+            local dir = vim.fn.expand("%:p:h")
+            vim.cmd("bd")
+            require("oil").open(dir)
+          end
+        '';
+        options.desc = "delete current buffer and return to oil";
+      }
+      # from the oil.nvim plugin spec
+      {
+        mode = "n";
+        key = "-";
+        action = "<CMD>Oil<CR>";
+        options.desc = "Open parent directory";
+      }
+    ];
+
+    # vim.api.nvim_create_user_command("Q", "q!", {})
+    userCommands.Q.command = "q!";
+
+    # EdenEast/nightfox.nvim
+    colorschemes.nightfox.enable = true;
+
+    plugins = {
+      # stevearc/oil.nvim
+      oil = {
+        enable = true;
+        settings = {
+          delete_to_trash = true;
+          view_options.show_hidden = true;
+        };
+      };
+
+      # luukvbaal/statuscol.nvim
+      statuscol = {
+        enable = true;
+        settings = {
+          setopt = true;
+          segments = [
+            {
+              text = [
+                {
+                  __raw = ''
+                    function(args)
+                      return "%#LineNr#" .. ("%2d "):format(args.lnum)
+                    end
+                  '';
+                }
+              ];
+            }
+            {
+              text = [
+                {
+                  __raw = ''
+                    function(args)
+                      return "%#CursorLineNr#" .. ("%2d "):format(args.relnum > 99 and 99 or args.relnum)
+                    end
+                  '';
+                }
+              ];
+            }
+          ];
+        };
+      };
+
+      # neovim/nvim-lspconfig (provides the default rust_analyzer config)
+      lspconfig.enable = true;
+
+      # ap/vim-css-color
+      vim-css-color.enable = true;
+
+      # rcarriga/nvim-notify (was a lazy.nvim dependency of noice)
+      notify.enable = true;
+
+      # folke/noice.nvim (nui.nvim comes in as a package dependency)
+      noice = {
+        enable = true;
+        settings = {
+          cmdline.enabled = true;
+          messages.enabled = false;
+        };
+      };
+    };
+
+    # vim.lsp.enable("rust_analyzer")
+    lsp.servers.rust_analyzer = {
+      enable = true;
+      # prefer rust-analyzer from the environment (rustup), fall back to nixpkgs
+      packageFallback = true;
+    };
+  };
+
+  # `v` / `ov` keep using plain neovim (hiPrio in home.nix); reach this config
+  # through the `nixvim` command.
+  home.packages = [
+    (pkgs.runCommand "nixvim-cmd" { } ''
+      mkdir -p $out/bin
+      ln -s ${config.programs.nixvim.build.package}/bin/nvim $out/bin/nixvim
+    '')
+  ];
+}


### PR DESCRIPTION
## Summary
- Add the `nixvim` flake input (`github:nix-community/nixvim/nixos-25.11`, nixpkgs follows ours) and a new `nix/home/nixvim.nix` home-manager module reproducing `.config/lua-nvim`.
- Reproduced: options (tabstop/shiftwidth=2, expandtab, cursorline, list, clipboard=unnamedplus, number/relativenumber), leader keys, keymaps (`x p`, terminal `<Esc>`, `Q` buffer-delete-to-oil, `-` → Oil), `:Q` command, nightfox, oil.nvim, statuscol.nvim (custom Lua segments via `__raw`), nvim-lspconfig + rust-analyzer (`packageFallback` so a rustup toolchain on PATH wins), vim-css-color, noice.nvim + nvim-notify.
- Coexistence with the current setup: `wrapRc = true` bakes the config into the wrapper so `~/.config/nvim` / `lua-nvim` and the Makefile symlinks are untouched; plain neovim keeps the `nvim` name via `lib.hiPrio` (aliases `v` / `ov` unchanged) and the nixvim build is available as **`nixvim`** (plus `nixvim-print-init`).

## Intentional differences
- lazy.nvim itself is dropped (nix replaces plugin management); noice's `VeryLazy` lazy-loading is omitted (nixvim doesn't lazy-load by default — behavior is equivalent).

## Verification
- `toof@linux` / `toof@mac` home configs and the kubevirt NixOS toplevel evaluate cleanly; `nix flake check --no-build` passes.
- Real build + headless run: options, colorscheme, maps, `:Q`, statuscol, and `vim.lsp.is_enabled("rust_analyzer")` all verified in the built `nixvim`.

Note: merge conflicts with #17/#20 on `home.nix` are expected and trivial (`imports = [ ./configs.nix ./nixvim.nix ];` and the neighboring comment lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)