### PR TITLE
fix: remove leftover merge conflict marker in home.nix

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -1,12 +1,12 @@
 # Shared Home Manager config (NixOS module / macOS standalone).
 #
-# ~/.zshrc is managed here (source of truth: ./zshrc; the repo-root .zshrc is
-# a symlink to it so the Makefile flow keeps working). The other config files
-# (git, tmux, nvim, ...) stay managed by the Makefile symlinks in this repo.
+# ~/.zshrc and the configs in ./config (git, gnupg, rustfmt, claude, herdr,
+# starship — see ./configs.nix) are managed here; the repo-root .zshrc and
+# .config/* entries are symlinks back so the Makefile flow keeps working.
+# The remaining config files (tmux, nvim, ssh, ...) stay Makefile-managed.
 { pkgs, lib, inputs, ... }:
 
 {
-<<<<<<< HEAD
   imports = [
     ./configs.nix
     ./nixvim.nix


### PR DESCRIPTION
## Summary
- The #20 merge resolution left a stray `<<<<<<< HEAD` at `nix/home/home.nix:9`, which breaks nix evaluation on main (the resolved content itself was correct — both `./configs.nix` and `./nixvim.nix` imported, zshrc lines intact). Remove the marker.
- Update the header comment: git/gnupg/rustfmt/claude/herdr/starship configs are now managed here via `configs.nix`; tmux/nvim/ssh stay Makefile-managed.

## Verification
- `git grep` finds no remaining conflict markers on the branch.
- `toof@linux` home config and the kubevirt NixOS toplevel evaluate cleanly again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)