### PR TITLE
ci: also run on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "nix/**"
+      - ".github/workflows/ci.yml"
   pull_request:
     paths:
       - "nix/**"


### PR DESCRIPTION
## Summary
Follow-up to #23 — this commit was pushed after the PR was merged, so it never landed on main.

- Run the CI workflow on pushes to main touching `nix/**` (same paths filter as the PR trigger)
- Keeps main's status visible and refreshes the Nix store caches on the base branch so PR runs can restore them

🤖 Generated with [Claude Code](https://claude.com/claude-code)