### PR TITLE
feat: add VM badge to prompt and manage git-prompt.sh via nix

### DIFF
--- a/nix/home/config/starship.toml
+++ b/nix/home/config/starship.toml
@@ -3,10 +3,18 @@
 add_newline = false
 
 format = """
-$username@$hostname $kubernetes $git_branch $git_commit$git_state$git_status$fill$time
+${custom.vm}$username@$hostname $kubernetes $git_branch $git_commit$git_state$git_status$fill$time
 $directory
 $character
 """
+
+# Show a bright "VM" badge when running inside a virtual machine
+# (systemd-detect-virt --vm: kvm on the kubevirt VM, none on bare metal;
+# not present on macOS, so the module is simply skipped there).
+[custom.vm]
+when = "systemd-detect-virt --vm -q"
+style = "bold fg:black bg:yellow"
+format = '[ VM ]($style) '
 
 [character]
 success_symbol = '[\$](bold green)'

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -18,6 +18,11 @@
 
   home.file.".zshrc".source = ./zshrc;
 
+  # .zshrc sources ~/.zsh/git-prompt.sh; the Makefile curls it from git
+  # upstream, but on nix-managed machines ship the one bundled with git.
+  home.file.".zsh/git-prompt.sh".source =
+    "${pkgs.git}/share/git/contrib/completion/git-prompt.sh";
+
   home.packages = with pkgs; [
     # shell
     zsh


### PR DESCRIPTION
## Summary
- **starship**: show a bold black-on-yellow ` VM ` badge at the start of the prompt when the shell runs inside a virtual machine, detected with `systemd-detect-virt --vm -q` (returns `kvm` on the kubevirt VM, `none` on bare metal; the command doesn't exist on macOS so the module is skipped there, and WSL is not detected as a VM).
- **home-manager**: ship `~/.zsh/git-prompt.sh` from the git package's bundled `contrib/completion/git-prompt.sh`. The nix-managed `.zshrc` sources this file, but until now it only existed on machines that had run the Makefile (`curl` from git upstream), so shells on the VM printed `no such file or directory: /home/toof/.zsh/git-prompt.sh`. The Makefile itself is unchanged.

## Test plan
- `nix eval` passes for `homeConfigurations."toof@linux"` and `nixosConfigurations.kubevirt`
- Rendered the prompt with `STARSHIP_CONFIG` pointing at the new config: badge shows when the `when` condition is true, hidden otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)