### PR TITLE
feat: add GHCR publish guide and merge/push policy to CLAUDE.md

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -2,6 +2,10 @@
 
 All commits must be GPG-signed. Never commit with signing disabled (e.g. `--no-gpg-sign` or `commit.gpgsign=false`) — if signing fails, stop and report the error instead of working around it.
 
+# Merge / push policy
+
+Never merge a pull request (via `gh pr merge`, `gh api`, the merge button, or any other means) without the user's explicit approval. Never push directly to `main` — always create a branch and open a pull request instead.
+
 # PR comment policy
 
 Never post comments on pull requests (review comments, inline comments, or replies via `gh pr comment`, `gh api`, etc.) without the user's explicit approval. Draft the comment and show it to the user first.
@@ -9,6 +13,17 @@ Never post comments on pull requests (review comments, inline comments, or repli
 # Environment
 
 Repositories are managed with [ghq](https://github.com/x-motemen/ghq), so this repo lives under `~/ghq/github.com/toof-jp/dotfiles` rather than a flat `~/dotfiles` path.
+
+# GHCR image publishing (CI)
+
+When a repository needs CI that builds Docker images and pushes them to ghcr.io, follow the `ghcr-publish` skill (`~/.config/claude/skills/ghcr-publish/SKILL.md` — full workflow templates live there). Key rules:
+
+- Detect Dockerfiles first, then pick the pattern:
+  - One Dockerfile at repo root → single workflow `.github/workflows/build-push.yml`, image `ghcr.io/<owner>/<repo>`.
+  - Multiple Dockerfiles in subdirectories (monorepo) → one workflow per service `.github/workflows/<service>-ci.yml`, image `ghcr.io/<owner>/<repo>-<service>`, with a `paths` filter covering both the service directory and the workflow file itself.
+- Every workflow needs: `permissions: contents: read` + `packages: write`; `docker/setup-buildx-action`; `docker/login-action` with `${{ github.actor }}` / `${{ secrets.GITHUB_TOKEN }}`; `docker/metadata-action` with tags `latest` (default branch only) + `sha` + git tag and the `org.opencontainers.image.source` label; `docker/build-push-action` with `push: true`, `platforms: linux/amd64`, and GHA cache (`cache-from`/`cache-to: type=gha`).
+- Verify the default branch name (`main` vs `master`) matches the repo.
+- After writing workflows, run `pinact run` to pin actions and resolve any reported issues before finishing.
 
 # Worktree management
 


### PR DESCRIPTION
## Summary

Adds two sections to the global CLAUDE.md (`nix/home/config/claude/CLAUDE.md`):

- **GHCR image publishing (CI)** — condensed guide from the `ghcr-publish` skill: single-container vs monorepo workflow patterns, image naming (`ghcr.io/<owner>/<repo>[-<service>]`), required workflow elements (permissions, Buildx, GITHUB_TOKEN login, metadata-action tags, GHA cache), and running `pinact run` after writing workflows. Full templates remain in `.config/claude/skills/ghcr-publish/SKILL.md`.
- **Merge / push policy** — never merge a PR without explicit user approval, and never push directly to `main`; always branch and open a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)