### PR TITLE
ci: push builds to Cachix and drop cache-nix-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ on:
 
 permissions:
   contents: read
-  # cache-nix-action purges stale caches via the Actions API
-  actions: write
+
+env:
+  # secrets are not available in step-level if:, so gate the cachix steps
+  # through the env context (empty on fork PRs and until the token is set)
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,6 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        if: env.CACHIX_AUTH_TOKEN != ''
+        with:
+          name: toof-jp
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix flake check ./nix --all-systems
 
   build-linux:
@@ -53,18 +61,11 @@ jobs:
 
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
-      - name: Restore/save Nix store cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        if: env.CACHIX_AUTH_TOKEN != ''
         with:
-          primary-key: nix-${{ runner.os }}-${{ matrix.name }}-${{ hashFiles('nix/flake.lock', 'nix/**/*.nix') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-${{ matrix.name }}-
-          # Keep each cache small enough that the 10GB repo cache quota
-          # holds all four jobs without evicting each other
-          gc-max-store-size-linux: 2G
-          purge: true
-          purge-prefixes: nix-${{ runner.os }}-${{ matrix.name }}-
-          purge-created: 0
-          purge-primary-key: never
+          name: toof-jp
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build ${{ matrix.attr }}
         run: nix build './nix#${{ matrix.attr }}' --no-link --print-build-logs
@@ -75,16 +76,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
-      - name: Restore/save Nix store cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        if: env.CACHIX_AUTH_TOKEN != ''
         with:
-          primary-key: nix-${{ runner.os }}-home-mac-${{ hashFiles('nix/flake.lock', 'nix/**/*.nix') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-home-mac-
-          gc-max-store-size-darwin: 2G
-          purge: true
-          purge-prefixes: nix-${{ runner.os }}-home-mac-
-          purge-created: 0
-          purge-primary-key: never
+          name: toof-jp
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build homeConfigurations."toof@mac".activationPackage
         run: nix build './nix#homeConfigurations."toof@mac".activationPackage' --no-link --print-build-logs

--- a/.github/workflows/vm-image.yml
+++ b/.github/workflows/vm-image.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -27,6 +30,12 @@ jobs:
           df -h /
 
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        if: env.CACHIX_AUTH_TOKEN != ''
+        with:
+          name: toof-jp
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build qcow2
         run: |


### PR DESCRIPTION
## 概要

nix ビルドの高速化のため、cache-nix-action(GitHub Actions キャッシュ)をやめて Cachix にビルド結果を push するようにします。

## 背景

- Actions キャッシュのクォータ 10GB を 4 ジョブで分け合うため、ストアを 2GB に切り詰めており、flake を変更するたびにキーが外れてほぼフルビルドになっていた(直近の計測でビルド 5〜6 分、キャッシュ復元 0 秒 = ミス)
- Cachix なら closure 全体を保持でき、CI だけでなくローカルの `home-manager switch`(mac / Arch)も substitute の恩恵を受けられる

## 変更内容

- 全ジョブに `cachix/cachix-action@v17`(SHA ピン)を追加(cache 名 `toof-jp`)
- `CACHIX_AUTH_TOKEN` が未設定の場合(fork PR 含む)は cachix ステップをスキップし、CI 自体は従来通り通る
- `cache-nix-action` と purge 用の `actions: write` permission を削除
- `vm-image.yml` にも Cachix を追加(qcow2 ビルドが kubevirt-base の closure を substitute できる)

## マージ後に必要な作業(キャッシュを有効化するまで効果なし)

1. https://app.cachix.org で GitHub アカウント連携し、`toof-jp` という名前の public cache を作成(OSS 無料枠 5GB)
2. Auth Token を発行し、リポジトリ secret `CACHIX_AUTH_TOKEN` に登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)