### PR TITLE
feat: add opencode to home-manager packages

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -62,6 +62,7 @@
     # AI agents
     claude-code # alias c='claude'
     codex # alias cx='codex'
+    opencode
 
     # crypto
     gnupg # gpg --card-status


### PR DESCRIPTION
## Summary
- Add `opencode` (v1.18.3 in nixpkgs) to `home.packages` in the AI agents section of `nix/home/home.nix`

## Test plan
- [x] `nix build .#homeConfigurations."toof@linux".activationPackage` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)