### PR TITLE
feat: set Claude Code defaultMode to auto and update vm alias

### DIFF
--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -2,5 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "model": "claude-fable-5[1m]",
   "skipDangerousModePermissionPrompt": true,
+  "permissions": {
+    "defaultMode": "auto"
+  },
   "cleanupPeriodDays": 99999999
 }

--- a/nix/home/zshrc
+++ b/nix/home/zshrc
@@ -26,7 +26,7 @@ bindkey -e
 source <(fzf --zsh)
 
 # alias
-alias vm='ssh -p 30022 toof@localhost'
+alias vm='ssh toof@dev-vm'
 alias c='claude'
 alias cdp='c --dangerously-skip-permissions'
 alias ca='cargo'


### PR DESCRIPTION
## Summary
- Add `permissions.defaultMode: "auto"` to Claude Code settings.json
- Change the `vm` alias from `ssh -p 30022 toof@localhost` to `ssh toof@dev-vm`

## Test plan
- [ ] `nix` home config builds (CI)
- [ ] `vm` alias resolves via `dev-vm` SSH host config

🤖 Generated with [Claude Code](https://claude.com/claude-code)