### PR TITLE
feat: follow-up to Claude Code permission allowlist

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -39,4 +39,6 @@ git gtr rm <branch>        # remove it when done
 git gtr ls                 # list worktrees
 ```
 
+After a pull request is merged, remove its local worktree with `git gtr rm <branch>`.
+
 Worktrees are created under `.worktrees/` inside the repo (`gtr.worktrees.dir = .worktrees`, set globally). This directory is ignored via the global gitignore (`.config/git/ignore`), so it never needs to be added per-repo.

--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -14,6 +14,7 @@
       "Bash(jq *)",
       "Bash(python *)",
       "Bash(python3 *)",
+      "Bash(uv *)",
       "Bash(op read *)",
       "Bash(opencode *)",
       "Bash(kubectl get *)",

--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -15,7 +15,6 @@
       "Bash(python *)",
       "Bash(python3 *)",
       "Bash(op read *)",
-      "Bash(rm *)",
       "Bash(opencode *)",
       "Bash(kubectl get *)",
       "Bash(kubectl describe *)",


### PR DESCRIPTION
## Summary
- Drop `Bash(rm *)` from the allowlist — prefix rules cannot exclude dangerous variants like `rm -rf ~`, so rm goes back to auto mode's classifier
- Allow `uv *`
- Document in CLAUDE.md that merged PRs' local worktrees should be removed with `git gtr rm <branch>`

Follow-up to #33 (these commits were pushed after it was merged).

## Test plan
- [ ] `jq -e . nix/home/config/claude/settings.json` passes (validated locally)
- [ ] Rebuild home-manager and confirm rm prompts again while uv runs without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)