### PR TITLE
feat: treat right option as alt in ghostty

### DIFF
--- a/nix/home/config/ghostty/config
+++ b/nix/home/config/ghostty/config
@@ -1,0 +1,1 @@
+macos-option-as-alt = right

--- a/nix/home/configs.nix
+++ b/nix/home/configs.nix
@@ -15,6 +15,8 @@
     "rustfmt".source = ./config/rustfmt;
 
     "herdr/config.toml".source = ./config/herdr/config.toml;
+
+    "ghostty/config".source = ./config/ghostty/config;
   };
 
   home.file = {


### PR DESCRIPTION
## Summary
- Add `nix/home/config/ghostty/config` with `macos-option-as-alt = right` so the right Option key acts as Alt in Ghostty (left Option stays available for symbol input)
- Deploy it to `~/.config/ghostty/config` via home-manager in `nix/home/configs.nix`

## Test plan
- [ ] Rebuild home-manager on the mac and confirm `~/.config/ghostty/config` is linked
- [ ] In Ghostty, verify right Option sends Alt sequences and left Option still types symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)