### PR TITLE
fix: pull gh-dash from nixpkgs-unstable to fix checks-bar panic

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -123,6 +123,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1782847189,
@@ -191,6 +207,7 @@
         "herdr": "herdr",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nixvim": "nixvim"
       }
     },

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
       url = "github:nix-community/home-manager/release-25.11";
@@ -23,12 +24,22 @@
     let
       username = "toof";
 
+      overlays = [
+        # 25.11's gh-dash 4.18.0 panics on narrow sidebars (negative
+        # strings.Repeat count in the checks bar); fixed upstream in 4.25.2
+        (final: prev: {
+          gh-dash =
+            inputs.nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system}.gh-dash;
+        })
+      ];
+
       mkPkgs = system: import nixpkgs {
-        inherit system;
+        inherit system overlays;
         config.allowUnfree = true; # claude-code etc.
       };
 
       homeManagerModules = [
+        { nixpkgs.overlays = overlays; }
         home-manager.nixosModules.home-manager
         {
           home-manager.useGlobalPkgs = true;


### PR DESCRIPTION
## Summary
- gh-dash 4.18.0 (nixos-25.11) crashes with `panic: strings: negative Repeat count` in `prsidebar/checks.go:277` when the PR checks bar is rendered in a narrow sidebar
- Upstream fixed this by v4.25.2 (clamps the bar width to 0), but 25.11 still ships 4.18.0
- Adds a `nixpkgs-unstable` input and overlays `gh-dash` from it (4.25.2), applied to both standalone home-manager configs and NixOS hosts

## Test plan
- [x] `nix eval .#homeConfigurations."toof@linux".pkgs.gh-dash.version` → 4.25.2
- [x] `nix eval .#nixosConfigurations.dev.pkgs.gh-dash.version` → 4.25.2
- [x] Built the overlaid package from cache and confirmed `gh-dash --version` reports 4.25.2
- [ ] After merge: `home-manager switch`, then reproduce the previous crash scenario (narrow sidebar with checks) and confirm no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)