### PR TITLE
feat: allow terraform in Claude Code permissions

### DIFF
--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(pinact *)",
       "Bash(docker *)",
       "Bash(docker-compose *)",
+      "Bash(terraform *)",
       "Bash(printf *)",
       "Bash(sed *)",
       "Bash(echo)",


### PR DESCRIPTION
## Summary
- Add `Bash(terraform *)` to the Claude Code global permission allowlist (nix-managed settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)