### PR TITLE
feat: add kimi command for Claude Code on Moonshot Kimi K3

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -63,6 +63,7 @@
     claude-code # alias c='claude'
     codex # alias cx='codex'
     opencode
+    (callPackage ./kimi.nix { }) # kimi — Claude Code on Kimi K3
 
     # crypto
     gnupg # gpg --card-status

--- a/nix/home/kimi.nix
+++ b/nix/home/kimi.nix
@@ -1,0 +1,27 @@
+# `kimi` — Claude Code backed by Moonshot's Kimi K3 via its
+# Anthropic-compatible endpoint. The API key is read from 1Password at
+# launch (override the item with $KIMI_OP_ITEM), so nothing lands on disk.
+#
+# `op` is intentionally NOT a runtime input: the one on PATH is the
+# op-sa-wrapper (~/.cargo/bin/op, from toof-jp/op-sa-wrapper), which
+# injects the GPG-encrypted service-account token before delegating to
+# the real CLI. Shipping nixpkgs' op here would shadow it.
+{ writeShellApplication, claude-code }:
+
+writeShellApplication {
+  name = "kimi";
+  runtimeInputs = [ claude-code ];
+  text = ''
+    : "''${KIMI_OP_ITEM:=op://infra/Moonshot/credential}"
+
+    export ANTHROPIC_BASE_URL="https://api.moonshot.ai/anthropic"
+    ANTHROPIC_AUTH_TOKEN="$(op read "$KIMI_OP_ITEM")"
+    export ANTHROPIC_AUTH_TOKEN
+    export ANTHROPIC_MODEL="kimi-k3"
+    export ANTHROPIC_SMALL_FAST_MODEL="kimi-k3"
+    unset ANTHROPIC_API_KEY
+
+    exec claude "$@"
+  '';
+  meta.description = "Claude Code wrapper running on Moonshot Kimi K3";
+}


### PR DESCRIPTION
## Summary
- New `kimi` command: launches Claude Code with `ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic` and `ANTHROPIC_MODEL=kimi-k3`, so the existing `claude` binary talks to Moonshot's Anthropic-compatible endpoint.
- API key is fetched at launch via `op read` (default `op://infra/Moonshot/credential`, overridable with `$KIMI_OP_ITEM`), so no secret is written to disk or the store.
- `op` intentionally not in `runtimeInputs`: the `op` on PATH is [toof-jp/op-sa-wrapper](https://github.com/toof-jp/op-sa-wrapper), which injects a GPG-encrypted service-account token before delegating to the real CLI. Adding nixpkgs' `op` would shadow it.

## Test plan
- [ ] Create the 1Password item at `op://infra/Moonshot/credential` (or set `$KIMI_OP_ITEM`)
- [ ] `home-manager switch` picks up the new package
- [ ] `kimi --version` runs and shows the Claude Code version
- [ ] `kimi` in an interactive session hits Kimi K3 (model shown at startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)