### PR TITLE
feat(nuc): pin kubelet --node-ip to tailscale IP

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -105,6 +105,9 @@
     environment = {
       KUBELET_KUBECONFIG_ARGS = "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf";
       KUBELET_CONFIG_ARGS = "--config=/var/lib/kubelet/config.yaml";
+      # Cluster traffic flows over tailnet; without this kubelet advertises
+      # the LAN IP and pod-to-pod routing via the CNI breaks
+      KUBELET_EXTRA_ARGS = "--node-ip=100.112.113.18";
     };
     serviceConfig = {
       ExecStart = "${pkgs.kubernetes}/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS";


### PR DESCRIPTION
## Summary
- kubelet on the nuc node was advertising its LAN IP (`192.168.0.71`) after `kubeadm join`, but the rest of the cluster runs over tailnet — other workers (e.g. `oci-vps`) advertise `100.x.x.x`
- pin `--node-ip=100.112.113.18` (nuc's tailscale IP) via `KUBELET_EXTRA_ARGS` so CNI programs pod-to-pod routes to a tailnet-reachable address

## Test plan
- [ ] merge, then on nuc: `sudo nixos-rebuild switch --refresh`
- [ ] `kubectl get nodes -o wide` shows `nuc` with `INTERNAL-IP 100.112.113.18`
- [ ] once a CNI DaemonSet lands, `nuc` transitions to `Ready`