### PR TITLE
feat(nuc): enable systemd-resolved

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -50,6 +50,11 @@
   services.openssh.enable = true;
   services.openssh.settings.PasswordAuthentication = false;
 
+  # kubeadm-generated kubelet config pins resolvConf to
+  # /run/systemd/resolve/resolv.conf, so systemd-resolved must be running
+  # or pod sandboxes fail to start
+  services.resolved.enable = true;
+
   services.tailscale.enable = true;
   networking.firewall = {
     # Cluster traffic flows over the tailnet; nothing but SSH on the LAN


### PR DESCRIPTION
## Summary
- kubeadm generates \`/var/lib/kubelet/config.yaml\` with \`resolvConf: /run/systemd/resolve/resolv.conf\`, but that path only exists when systemd-resolved is running
- without it, pod sandboxes fail with \`open /run/systemd/resolve/resolv.conf: no such file or directory\` and the node stays NotReady because CNI can never start
- observed after #42 landed: \`kube-flannel-ds-*\` stuck in Init:0/2 with \`FailedCreatePodSandBox\`

## Test plan
- [ ] merge, then on nuc: \`sudo nixos-rebuild switch --refresh\`
- [ ] \`kubectl get pods -A --field-selector spec.nodeName=nuc\` — flannel + kube-proxy reach Running
- [ ] \`kubectl get nodes\` shows \`nuc\` as Ready