### PR TITLE
fix(nuc): stop tmpfiles from dropping cni-plugins copy rule

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -83,8 +83,10 @@
     };
   };
 
+  # Two rules targeting the same path are rejected by systemd-tmpfiles as
+  # a duplicate, so create the parent and let C+ create/populate bin itself
   systemd.tmpfiles.rules = [
-    "d /opt/cni/bin 0755 root root -"
+    "d /opt/cni 0755 root root -"
     # C+ re-copies every boot so cni-plugins updates propagate; extra
     # binaries dropped in by CNI DaemonSets are left alone
     "C+ /opt/cni/bin - - - - ${pkgs.cni-plugins}/bin"


### PR DESCRIPTION
## Summary
- \`d /opt/cni/bin\` and \`C+ /opt/cni/bin\` both target the same path, so systemd-tmpfiles rejects the second line as a duplicate (\`/etc/tmpfiles.d/00-nixos.conf:5: Duplicate line for path "/opt/cni/bin", ignoring.\`)
- result: \`cni-plugins\` (loopback, bridge, host-local, ...) was never copied to \`/opt/cni/bin\`; only \`flannel\` was there because the flannel DaemonSet installs it at runtime
- symptom on the freshly-joined nuc: any pod that needed a fresh sandbox failed with \`plugin type="loopback" failed (add): failed to find plugin "loopback" in path [/opt/cni/bin]\` — longhorn-manager / csi-plugin / engine-image, plus everything that got rescheduled onto nuc (dawarich, shisha-log migrations, ...)
- fix: create the parent \`/opt/cni\` with \`d\`, let \`C+\` create and populate \`/opt/cni/bin\` itself (verified on-node that \`C+\` creates the destination directory when it doesn't exist)

## Test plan
- [ ] merge, then on nuc: \`sudo nixos-rebuild switch --refresh\`
- [ ] \`ssh toof@nuc 'ls /opt/cni/bin'\` — shows loopback, bridge, ..., plus flannel
- [ ] \`journalctl -b | grep tmpfiles | grep -i duplicate\` — no duplicate warning for /opt/cni/bin
- [ ] reboot the node, re-check the listing to confirm the copy runs at boot