### PR TITLE
feat(nuc): enable open-iscsi for longhorn

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -83,6 +83,14 @@
     };
   };
 
+  # Longhorn provisions block volumes via iSCSI, so longhorn-manager needs
+  # iscsiadm on the host — without it the pod exits with "please make sure
+  # you have iscsiadm/open-iscsi installed on the host"
+  services.openiscsi = {
+    enable = true;
+    name = "iqn.2026-07.jp.toof:nuc";
+  };
+
   # Two rules targeting the same path are rejected by systemd-tmpfiles as
   # a duplicate, so create the parent and let C+ create/populate bin itself
   systemd.tmpfiles.rules = [


### PR DESCRIPTION
## Summary
- longhorn-manager on the nuc crashed with \`please make sure you have iscsiadm/open-iscsi installed on the host\`; Longhorn attaches replicas as iSCSI block devices and needs \`iscsiadm\` inside the host mount namespace
- enable \`services.openiscsi\` (loads the iscsi kernel modules and starts iscsid) with an IQN scoped to this node

## Test plan
- [ ] merge, then on nuc: \`sudo nixos-rebuild switch --refresh\`
- [ ] \`ssh toof@nuc iscsiadm --version\` succeeds
- [ ] \`kubectl -n longhorn-system get pod -l app=longhorn-manager -o wide\` — nuc's replica reaches Running (2/2), no CrashLoopBackOff
- [ ] a Longhorn-backed pod (e.g. dawarich) can attach a volume on nuc after zen2 releases it