### PR TITLE
feat(nuc): shim iscsiadm at /usr/local/sbin for longhorn

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -98,6 +98,10 @@
     # C+ re-copies every boot so cni-plugins updates propagate; extra
     # binaries dropped in by CNI DaemonSets are left alone
     "C+ /opt/cni/bin - - - - ${pkgs.cni-plugins}/bin"
+    # longhorn-manager nsenter's into the host mount ns and exec's
+    # `iscsiadm` with its container's PATH (/usr/local/sbin:...:/sbin);
+    # none of those paths are populated on NixOS, so shim iscsiadm there
+    "L+ /usr/local/sbin/iscsiadm - - - - ${pkgs.openiscsi}/bin/iscsiadm"
   ];
 
   systemd.services.kubelet = {


### PR DESCRIPTION
## Summary
- follow-up to #45 — enabling \`services.openiscsi\` starts iscsid but longhorn-manager still crashes with \`nsenter: failed to execute iscsiadm: No such file or directory\`
- longhorn-manager runs \`nsenter --mount=/host/proc/<iscsid>/ns/mnt -- iscsiadm ...\`; the exec resolves \`iscsiadm\` via the container's PATH (\`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\`), none of which NixOS populates
- symlink \`/usr/local/sbin/iscsiadm\` → \`${pkgs.openiscsi}/bin/iscsiadm\` via \`L+\` in \`systemd.tmpfiles.rules\` so longhorn finds it after entering the host namespace

## Test plan
- [ ] merge, then on nuc: \`sudo nixos-rebuild switch --refresh\`
- [ ] \`ssh toof@nuc readlink /usr/local/sbin/iscsiadm\` → points into /nix/store
- [ ] \`kubectl -n longhorn-system get pod -l app=longhorn-manager --field-selector spec.nodeName=nuc\` → Running 2/2, no CrashLoopBackOff
- [ ] dawarich (after RWO release) attaches its Longhorn volume on nuc