### PR TITLE
ci: enable Renovate for Nix flake inputs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,13 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", ":dependencyDashboard"],
+  // Only track Nix flake inputs for now; leave GitHub Actions to pinact.
+  enabledManagers: ["nix"],
+  nix: {
+    enabled: true,
+  },
+  // Keep flake.lock fresh even when no input's ref changes (branch pins move).
+  lockFileMaintenance: {
+    enabled: true,
+  },
+}


### PR DESCRIPTION
## Summary
- Add `.github/renovate.json5` scoped to the `nix` manager only (GitHub Actions stay under `pinact`).
- Turn on `lockFileMaintenance` so branch-pinned inputs (e.g. `nixpkgs-25.11`) get their commit pins refreshed.
- No auto-merge — every Renovate PR is manually reviewed.

Motivation: keeping `pkgs.kubernetes` on the NUC (and other flake-driven packages) fresh without hand-editing `flake.lock`.

## Test plan
- [ ] `flake-check` and `build-linux` CI jobs pass on this PR
- [ ] After merge, confirm Renovate app is installed on the repo (`gh api repos/toof-jp/dotfiles/installation`); install from https://github.com/apps/renovate if not
- [ ] Verify a Dependency Dashboard issue is created and flake input update PRs start showing up