### PR TITLE
docs(claude): pull main before creating a worktree

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -31,6 +31,8 @@ When a repository needs CI that builds Docker images and pushes them to ghcr.io,
 
 Always start new work by creating a worktree with `git gtr new` first, then work inside it — never work directly in the main checkout.
 
+Before creating a worktree, update `main` in the main checkout first (e.g. `git pull --ff-only` on `main`) so the new worktree branches off the latest `main`.
+
 Use `git gtr` (git-worktree-runner) to create git worktrees instead of `git worktree add`.
 
 ```


### PR DESCRIPTION
## Summary
- Add a rule to CLAUDE.md: update `main` (e.g. `git pull --ff-only`) in the main checkout before running `git gtr new`, so new worktrees branch off the latest `main` instead of stale local state.

## Test plan
- [x] `git diff --staged | opencode run` review