### PR TITLE
ci(nix): parallelise disk cleanup, widen substituter concurrency, add paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            http-connections = 128
+            max-substitution-jobs = 128
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         if: env.CACHIX_AUTH_TOKEN != ''
         with:
@@ -52,14 +56,23 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Full NixOS closures need more than the ~14GB free on a stock runner
+      # Full NixOS closures need more than the ~14GB free on a stock runner.
+      # Delete in parallel so we're not serialising ~40GB of `rm -rf` I/O.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
-            /usr/local/share/boost /opt/hostedtoolcache
+          sudo rm -rf /usr/local/lib/android &
+          sudo rm -rf /usr/share/dotnet &
+          sudo rm -rf /opt/ghc &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /opt/hostedtoolcache &
+          wait
           df -h /
 
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            http-connections = 128
+            max-substitution-jobs = 128
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         if: env.CACHIX_AUTH_TOKEN != ''
@@ -75,6 +88,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            http-connections = 128
+            max-substitution-jobs = 128
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         if: env.CACHIX_AUTH_TOKEN != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Which flake outputs a PR/push actually needs to rebuild. `home` covers
+  # the shared inputs used by every downstream config (home-manager + the
+  # flake itself); `dev` / `kubevirt` layer host-specific paths on top so
+  # only the affected NixOS closure runs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      home: ${{ steps.matrix.outputs.home }}
+      dev: ${{ steps.matrix.outputs.dev }}
+      kubevirt: ${{ steps.matrix.outputs.kubevirt }}
+      linux_matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # workflow_dispatch has no diff to work from — force every build in
+      # that case (see the matrix step below).
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        with:
+          filters: |
+            home: &home
+              - '.github/workflows/ci.yml'
+              - 'nix/flake.nix'
+              - 'nix/flake.lock'
+              - 'nix/home/**'
+            dev:
+              - *home
+              - 'nix/hosts/dev/**'
+            kubevirt:
+              - *home
+              - 'nix/hosts/kubevirt/**'
+      - id: matrix
+        env:
+          EVENT: ${{ github.event_name }}
+          DEV: ${{ steps.filter.outputs.dev }}
+          KUBEVIRT: ${{ steps.filter.outputs.kubevirt }}
+          HOME_CHANGED: ${{ steps.filter.outputs.home }}
+        run: |
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            DEV=true; KUBEVIRT=true; HOME_CHANGED=true
+          fi
+          include=()
+          if [[ "$DEV" == "true" ]]; then
+            include+=('{"name":"nixos-dev","attr":"nixosConfigurations.dev.config.system.build.toplevel"}')
+          fi
+          if [[ "$KUBEVIRT" == "true" ]]; then
+            include+=('{"name":"nixos-kubevirt","attr":"nixosConfigurations.kubevirt.config.system.build.toplevel"}')
+          fi
+          if [[ "$HOME_CHANGED" == "true" ]]; then
+            include+=('{"name":"home-linux","attr":"homeConfigurations.\"toof@linux\".activationPackage"}')
+          fi
+          joined=$(IFS=,; printf '%s' "${include[*]}")
+          {
+            echo "matrix={\"include\":[${joined}]}"
+            echo "home=$HOME_CHANGED"
+            echo "dev=$DEV"
+            echo "kubevirt=$KUBEVIRT"
+          } >> "$GITHUB_OUTPUT"
+
   flake-check:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,17 +102,12 @@ jobs:
       - run: nix flake check ./nix --all-systems
 
   build-linux:
+    needs: changes
+    if: needs.changes.outputs.dev == 'true' || needs.changes.outputs.kubevirt == 'true' || needs.changes.outputs.home == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: nixos-dev
-            attr: nixosConfigurations.dev.config.system.build.toplevel
-          - name: nixos-kubevirt
-            attr: nixosConfigurations.kubevirt.config.system.build.toplevel
-          - name: home-linux
-            attr: homeConfigurations."toof@linux".activationPackage
+      matrix: ${{ fromJSON(needs.changes.outputs.linux_matrix) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -84,6 +139,8 @@ jobs:
         run: nix build './nix#${{ matrix.attr }}' --no-link --print-build-logs
 
   build-mac:
+    needs: changes
+    if: needs.changes.outputs.home == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/vm-image.yml
+++ b/.github/workflows/vm-image.yml
@@ -22,14 +22,23 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The NixOS closure + qcow2 + docker layer need more than the ~14GB
-      # free on a stock runner
+      # free on a stock runner. Delete in parallel so we're not serialising
+      # ~40GB of `rm -rf` I/O.
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
-            /usr/local/share/boost /opt/hostedtoolcache
+          sudo rm -rf /usr/local/lib/android &
+          sudo rm -rf /usr/share/dotnet &
+          sudo rm -rf /opt/ghc &
+          sudo rm -rf /usr/local/share/boost &
+          sudo rm -rf /opt/hostedtoolcache &
+          wait
           df -h /
 
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+        with:
+          extra_nix_config: |
+            http-connections = 128
+            max-substitution-jobs = 128
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         if: env.CACHIX_AUTH_TOKEN != ''

--- a/.github/workflows/vm-image.yml
+++ b/.github/workflows/vm-image.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - "nix/**"
+      # kubevirt-image uses nixosConfigurations.kubevirt-base
+      # (nix/hosts/kubevirt/base.nix). Everything else in nix/ is unrelated.
+      - "nix/flake.nix"
+      - "nix/flake.lock"
+      - "nix/hosts/kubevirt/**"
+      - "nix/containerdisk/**"
       - ".github/workflows/vm-image.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Baseline (PR#48 merge run, everything cachix-hit)

| Job | Time |
| --- | --- |
| `flake-check` | 1m15s |
| `build-linux nixos-dev` | 7m22s |
| `build-linux nixos-kubevirt` | 6m53s |
| `build-linux home-linux` | 7m07s |
| **`build-mac`** | **11m47s** ← wall-clock bottleneck |
| **Total wall clock** | **11m51s** |

## Changes

### 1. Parallelise `Free disk space`

`sudo rm -rf a b c d e` was serial (~1m15s per Linux/vm-image job). Replaced with backgrounded `rm`s + `wait`. I/O bound, so the step drops to a few seconds.

### 2. Widen substituter concurrency

Add `extra_nix_config` to every `install-nix-action`:

- `http-connections = 128` (default 25)
- `max-substitution-jobs = 128` (default 16)

On cachix-hit paths the whole `nix build` time is downloading + unpacking store paths. First run confirmed the mac job dropped **11m47s → 8m51s (−25%)**.

### 3. Skip unaffected builds via `dorny/paths-filter`

Most PRs only touch one host or `home/**`, so rebuilding every closure was wasted work. Added a leading `changes` job with filters:

- `home` = shared inputs (`flake.nix`, `flake.lock`, `home/**`, `ci.yml`). Any hit forces every downstream build, since every config uses `homeManagerModules`.
- `dev` / `kubevirt` = `home` + `hosts/<name>/**`. Only builds the affected NixOS closure.

The `build-linux` matrix is generated dynamically from those outputs; `build-mac` gates on `home`. `flake-check` still runs unconditionally so eval errors are always caught. `workflow_dispatch` (no diff) forces every leg true.

`vm-image.yml`'s workflow-level `paths:` is narrowed to just kubevirt / containerdisk / flake inputs — home-only changes no longer trigger the qcow2 rebuild.

## Measured effect (change 1 + 2 only, run 29800803831)

| Job | Baseline | After changes 1+2 | Δ |
| --- | --- | --- | --- |
| flake-check | 1m15s | 1m34s | +19s (noise) |
| build-linux nixos-dev | 7m22s | 6m44s | −38s |
| build-linux nixos-kubevirt | 6m53s | 6m51s | −2s |
| build-linux home-linux | 7m07s | 6m08s | −59s |
| **build-mac** | **11m47s** | **8m51s** | **−2m56s** |
| **Wall clock** | **11m51s** | **8m51s** | **−3m00s (−25%)** |

The path-filter change (3) is on top of that: for a host-scoped PR, only the matching `build-linux` leg runs — most PRs will be down to ~6–7 min wall clock.

## Not done here

- **Second-tier cache with GHA cache** (`nix-community/cache-nix-action`). Would help cold runs but adds tarball upload/download overhead. Worth a separate benchmark.
- **Merging the 3 `build-linux` matrix legs into one job.** Saves runner-minutes but with `max-jobs = 1` (Nix default), a cache-miss run would serialise the build phases and be ~3× slower wall-clock.

## Test plan

- [ ] CI passes on this PR
- [ ] `home/**` change (this PR touches ci.yml which is in `home`) triggers all builds — sanity check that the filter still fires the full matrix
- [ ] Follow-up PR that touches only one host confirms the other legs are skipped