### PR TITLE
feat(nuc): pin kubernetes/cri-tools to nixpkgs-unstable (1.36.x)

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -90,10 +90,23 @@
         };
 
         # Intel NUC: Kubernetes node (tailscale + kubeadm), installed from
-        # the minimal ISO below
+        # the minimal ISO below.
+        # kubernetes / cri-tools come from nixpkgs-unstable so the control
+        # plane stays on the same minor as the workers in nix-sandbox (both
+        # currently 1.36.x); nixos-25.11 lags at 1.34.
         nuc = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
-          modules = [ ./hosts/nuc/configuration.nix ];
+          modules = [
+            ./hosts/nuc/configuration.nix
+            {
+              nixpkgs.overlays = [
+                (final: prev: {
+                  inherit (inputs.nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system})
+                    kubernetes cri-tools;
+                })
+              ];
+            }
+          ];
         };
 
         # Minimal installer ISO: boot + network + SSH; the real system is


### PR DESCRIPTION
## Summary

- `nixos-25.11` は現時点で `kubernetes` 1.34.3 をピンしているが、`nix-sandbox` 側のワーカーノード（sakura / vultr / oci、`nixos-26.05` 追随）は既に 1.36.2 で動いている。コントロールプレーンが workers より古いのは kubeadm の skew 的にもまずいので、NUC だけ最新に揃える。
- NUC ホストにだけ overlay を追加し、`kubernetes` と `cri-tools` を `nixpkgs-unstable`（現在 1.36.2 / 1.36.0）から供給。`dev` / `kubevirt` ホストは 25.11 のまま。
- `nix eval .#nixosConfigurations.nuc.pkgs.kubernetes.version` → `1.36.2`、`kubelet.serviceConfig.ExecStart` が `kubernetes-1.36.2/bin/kubelet` を指すことを確認済み。

## Test plan

- [ ] NUC 上で `sudo nixos-rebuild switch --refresh --flake 'github:toof-jp/dotfiles?dir=nix#nuc'` を実行してビルドが通ることを確認
- [ ] `kubelet --version` / `kubeadm version` が `v1.36.2` になっていることを確認
- [ ] control-plane 起動時は `kubeadm upgrade` 手順（未初期化なら不要）を必要に応じて実施