### PR TITLE
feat(nuc): add ISDB-T tuner + B-CAS reader support

### DIFF
--- a/nix/hosts/nuc/configuration.nix
+++ b/nix/hosts/nuc/configuration.nix
@@ -14,6 +14,10 @@
 { config, pkgs, ... }:
 
 {
+  imports = [
+    ./tv-tuner.nix
+  ];
+
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Lets plain `sudo nixos-rebuild switch` work on the node (nixos-rebuild

--- a/nix/hosts/nuc/tv-tuner.nix
+++ b/nix/hosts/nuc/tv-tuner.nix
@@ -1,0 +1,59 @@
+# Home ISDB-T recording stack: PLEX PX-S1UD x4 tuners + ACS ACR39U B-CAS
+# reader. Kernel drivers (smsusb / smsdvb) come with linux-firmware but the
+# smsdvb Siano Rio firmware is not redistributed by upstream, so we pull it
+# out of PLEX's Windows driver zip and place it via hardware.firmware.
+{ config, pkgs, lib, ... }:
+
+let
+  px-s1ud-firmware = pkgs.stdenvNoCC.mkDerivation {
+    pname = "px-s1ud-firmware";
+    version = "1.0.1";
+
+    src = pkgs.fetchurl {
+      url = "http://www.plex-net.co.jp/plex/px-s1ud/PX-S1UD_driver_Ver.1.0.1.zip";
+      sha256 = "05p963vc3x7spa3gn7hyiygg1b308ljvvm1nnbhah55921icx7ql";
+    };
+
+    nativeBuildInputs = [ pkgs.unzip ];
+    dontConfigure = true;
+    dontBuild = true;
+
+    # stdenv's unpackPhase cd's into PX-S1UD_driver_Ver.1.0.1/ (the single
+    # top-level directory in the zip), so the path is relative to that.
+    installPhase = ''
+      runHook preInstall
+      install -Dm444 x64/amd64/isdbt_rio.inp \
+        $out/lib/firmware/isdbt_rio.inp
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Firmware for PLEX PX-S1UD (Siano Rio smsdvb) ISDB-T USB tuner";
+      homepage = "http://www.plex-net.co.jp/plex/px-s1ud/";
+      license = licenses.unfreeRedistributable;
+      platforms = platforms.linux;
+    };
+  };
+in
+{
+  nixpkgs.config.allowUnfree = true;
+
+  hardware.firmware = [ px-s1ud-firmware ];
+
+  # smsusb/smsdvb are auto-loaded by udev on device probe, but list them
+  # explicitly so they're pinned into the initrd search path and so a
+  # rebuild that changes the kernel keeps them available.
+  boot.kernelModules = [ "smsusb" "smsdvb" ];
+
+  # ACS ACR39U is a CCID reader; pcscd + libccid is enough. mirakc reaches
+  # the daemon through /run/pcscd/pcscd.comm mounted into the pod.
+  services.pcscd = {
+    enable = true;
+    plugins = [ pkgs.ccid ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    pcsc-tools   # pcsc_scan for reader diagnostics
+    v4l-utils    # dvbv5-zap for tuning diagnostics
+  ];
+}


### PR DESCRIPTION
## Summary

nuc（Intel NUC k8s ワーカー）に ISDB-T 録画スタックの土台を追加します。

- **チューナー firmware**: PLEX PX-S1UD × 4本用の `isdbt_rio.inp` を PLEX公式 Windows ドライバ zip から抽出し、`hardware.firmware` で配置する derivation を追加（SHA256 pin済み再現可能）。`linux-firmware` パッケージには含まれていないため、これがないと `smsdvb` の周波数チューニングが失敗します。
- **kernel modules**: `smsusb` / `smsdvb` を `boot.kernelModules` に明示登録
- **B-CAS リーダー**: `services.pcscd` を有効化し、CCID プラグイン（ACS ACR39U 用）を追加
- **診断ツール**: `pcsc-tools`（`pcsc_scan`）、`v4l-utils`（`dvbv5-zap`）を導入

## 背景

自宅k8sクラスタで mirakc + EPGStation の録画サーバーを立ち上げる準備。実機（nuc）の USB に PX-S1UD × 4 と ACR39U を接続済みで、`/dev/dvb/adapter{0..3}` は生成されているものの firmware ロード失敗（`Direct firmware load for isdbt_rio.inp failed with error -2`）で復調不可の状態でした。

k8s マニフェスト側（mirakc / EPGStation Deployment、channels.yml、EPGStation SQLite PVC 等）は `toof-jp/infra` 側の別PRで対応します。

## 変更範囲・影響

- 追加した項目は firmware / kernel module / pcscd / 診断ツールのみ。containerd / kubelet / Longhorn / Tailscale / iSCSI 周りには一切触っていません
- `nixpkgs.config.allowUnfree = true` は tv-tuner.nix 内で設定（この host 全体に適用）
- opencode diff レビュー済み — 具体的な問題指摘なし

## Test plan

- [x] `nix build .#nixosConfigurations.nuc.config.system.build.toplevel` がローカルで成功
- [x] 出力ストアに `/lib/firmware/isdbt_rio.inp.zst`（NixOS の firmware zstd 圧縮）が生成されていることを確認
- [ ] マージ後、nuc 上で `sudo nixos-rebuild switch --flake 'github:toof-jp/dotfiles?dir=nix#nuc' --refresh`
- [ ] `sudo modprobe -r smsdvb smsusb && sudo modprobe smsusb` で firmware 再ロード、`dmesg` に error -2 が出ないこと
- [ ] `pcsc_scan -n` で ACS ACR39U と B-CAS カードが認識されること
- [ ] `dvbv5-zap` で 1 チャンネル試験受信 → mirakc 導入前の実機確認