### PR TITLE
docs(claude): direct new repo creation to github-repository-terraform

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -16,6 +16,10 @@ Never post comments on pull requests (review comments, inline comments, or repli
 
 Repositories are managed with [ghq](https://github.com/x-motemen/ghq), so this repo lives under `~/ghq/github.com/toof-jp/dotfiles` rather than a flat `~/dotfiles` path.
 
+# Creating new GitHub repositories
+
+New GitHub repositories under `toof-jp` are managed declaratively by [`toof-jp/github-repository-terraform`](https://github.com/toof-jp/github-repository-terraform) (`~/ghq/github.com/toof-jp/github-repository-terraform`). Do not create repositories via `gh repo create` or the web UI — instead, add a new entry to `repositories.json` in that repo and run `terraform apply` so the repo is created with the correct attributes and tracked in state.
+
 # GHCR image publishing (CI)
 
 When a repository needs CI that builds Docker images and pushes them to ghcr.io, follow the `ghcr-publish` skill (`~/.claude/skills/ghcr-publish/SKILL.md` — full workflow templates live there). Key rules:


### PR DESCRIPTION
## Summary
- Add a `Creating new GitHub repositories` section to `nix/home/config/claude/CLAUDE.md` instructing that new `toof-jp` repositories be added via [`toof-jp/github-repository-terraform`](https://github.com/toof-jp/github-repository-terraform) rather than `gh repo create` or the web UI, so all repos stay under declarative Terraform management.

## Test plan
- [x] `git diff` confirms the change is limited to the new section
- [x] Commit is GPG-signed
- [x] Staged diff reviewed by opencode before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)