### PR TITLE
chore(claude): drop pinned model default from settings.json

### DIFF
--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-fable-5[1m]",
   "skipDangerousModePermissionPrompt": true,
   "permissions": {
     "defaultMode": "auto",


### PR DESCRIPTION
## Summary
- Remove the `model` field from `nix/home/config/claude/settings.json` so Claude Code falls back to its built-in default instead of a hardcoded pin.

## Test plan
- [x] `home-manager switch --flake .#toof@linux` succeeds
- [x] Deployed `~/.claude/settings.json` no longer contains the `model` key