### PR TITLE
feat(gnupg): add no-autostart gpg.conf for non-Darwin hosts

### DIFF
--- a/nix/home/config/gnupg/gpg.conf
+++ b/nix/home/config/gnupg/gpg.conf
@@ -1,0 +1,5 @@
+# Do not autostart a local gpg-agent. Interactive shells launch one via
+# zshrc when $SSH_CONNECTION is unset, so a local session still has an
+# agent; over SSH we want gpg to use the RemoteForward'd socket from the
+# origin machine instead of a hijacking local agent + scdaemon.
+no-autostart

--- a/nix/home/configs.nix
+++ b/nix/home/configs.nix
@@ -33,5 +33,14 @@
     ".gnupg/gpg-agent.conf" = lib.mkIf pkgs.stdenv.isDarwin {
       source = ./config/gnupg/gpg-agent.conf;
     };
+
+    # Non-Darwin hosts receive gpg SSH-forwarded from a Mac (see
+    # .ssh/config.mac RemoteForward of S.gpg-agent). Without no-autostart,
+    # invoking `gpg` spawns a local gpg-agent + scdaemon that rebind the
+    # forwarded socket and break `gpg --card-status`. zshrc launches the
+    # agent explicitly for non-SSH sessions, so local usage still works.
+    ".gnupg/gpg.conf" = lib.mkIf (!pkgs.stdenv.isDarwin) {
+      source = ./config/gnupg/gpg.conf;
+    };
   };
 }


### PR DESCRIPTION
## Summary
- Adds `nix/home/config/gnupg/gpg.conf` with `no-autostart`, deployed via home-manager to non-Darwin hosts only
- Stops `gpg` on non-Darwin machines from spawning a local gpg-agent + scdaemon that would rebind the `S.gpg-agent` socket forwarded from the Mac (`.ssh/config.mac` RemoteForward), which was breaking `gpg --card-status` over SSH
- Darwin hosts are unaffected; `zshrc:206` still launches gpg-agent for non-SSH sessions on non-Darwin hosts

## Why
Repro: SSH from Mac to a non-Darwin host (zen2), run `gpg --card-status` → `Service is not running`. Cause: gpg auto-launched a local gpg-agent + scdaemon, unbinding the forwarded socket. With no local card, scdaemon errors out.

## Test plan
- [ ] Apply on zen2 (Arch, `toof@linux`): `home-manager switch --flake .#toof@linux`
- [ ] `cat ~/.gnupg/gpg.conf` shows `no-autostart`
- [ ] From Mac, `ssh zen2` fresh session → `gpg --card-status` returns the YubiKey without spawning local `gpg-agent`/`scdaemon`
- [ ] Local (non-SSH) shell on zen2 still gets a working agent (via zshrc launch)
- [ ] Verify Darwin `homeConfigurations.toof@mac` build is unchanged (no `.gnupg/gpg.conf` deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)