### PR TITLE
feat(nix): merge VPS k8s node configs from nix-sandbox

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -10,9 +10,16 @@ symlinks at the repo root (`make all`).
 nix/
 ├── flake.nix                 # inputs: nixos-25.11 + home-manager release-25.11 + herdr
 ├── home/home.nix             # shared Home Manager config (packages only)
-└── hosts/dev/
-    ├── configuration.nix     # NixOS system config
-    └── hardware-configuration.nix  # placeholder — generate on the real machine
+├── modules/                  # shared NixOS modules (k8s node, VPS installer)
+└── hosts/
+    ├── dev/                  # main workstation
+    ├── kubevirt/             # dev VM on KubeVirt (zen2)
+    ├── nuc/                  # Intel NUC k8s control-plane
+    ├── iso/                  # minimal installer ISO for NUC
+    ├── visionfive2/          # StarFive VisionFive 2 (riscv64) SD image
+    ├── sakura-vps/           # Sakura VPS k8s control-plane + installer ISO
+    ├── vultr-vps/            # Vultr VPS k8s node + installer ISO
+    └── oci-vps/              # OCI E2.1.Micro k8s node (nixos-infect-converted)
 ```
 
 ## Usage
@@ -65,6 +72,31 @@ nix build ./nix#kubevirt-image
 gcloud storage cp result/nixos.qcow2 gs://toof-infra-vm-images/nixos-dev.qcow2
 # then delete the dev-root DataVolume in the cluster to re-import
 ```
+
+### VPS k8s nodes (sakura / vultr / oci)
+
+Cheap-VPS kubeadm nodes joining the zen2 tailnet cluster. No Home Manager
+(too heavy for a 1–2 GB VPS); shared bits live in `modules/k8s-vps.nix` and
+`modules/kubernetes-node.nix`. Each host owns its hostname, tailscale
+`nodeIP`, `network.nix`, and `hardware-configuration.nix`.
+
+```sh
+# Build a provider installer ISO (sakura/vultr):
+nix build ./nix#sakura-installer-iso
+nix build ./nix#vultr-installer-iso
+
+# Then boot it in the VPS's control panel and run the baked-in installer:
+sakura-install   # or vultr-install — wipes /dev/vda and runs nixos-install
+```
+
+OCI's E2.1.Micro can't boot custom ISOs, so `oci-vps` was converted in
+place with nixos-infect — there is no `oci-installer`. See
+`hosts/sakura-vps/README.md` for the full sakura bring-up procedure
+(tailscale up, kubeadm join, etc.).
+
+`kubernetes` / `cri-tools` come from nixpkgs-unstable via
+`kubernetesOverlayModule` so every kubeadm node (nuc + all VPSs) stays on
+the same minor — nixos-25.11 lags at 1.34 while our cluster is on 1.36.
 
 ## Notes
 

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -43,6 +43,24 @@
         config.allowUnfree = true; # claude-code etc.
       };
 
+      # kubernetes / cri-tools come from nixpkgs-unstable so every host in
+      # our kubeadm clusters (nuc, sakura-vps, vultr-vps, oci-vps) stays on
+      # the same minor. Applied as its own module so hosts that don't need
+      # anything else k8s-specific just get the pin.
+      kubernetesOverlayModule = {
+        nixpkgs.overlays = [
+          (final: prev: {
+            inherit (inputs.nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system})
+              kubernetes cri-tools;
+          })
+        ];
+      };
+
+      mkK8sVps = configPath: nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [ configPath kubernetesOverlayModule ];
+      };
+
       homeManagerModules = [
         { nixpkgs.overlays = overlays; }
         home-manager.nixosModules.home-manager
@@ -89,31 +107,40 @@
           modules = [ ./hosts/kubevirt/base.nix ];
         };
 
-        # Intel NUC: Kubernetes node (tailscale + kubeadm), installed from
-        # the minimal ISO below.
-        # kubernetes / cri-tools come from nixpkgs-unstable so the control
-        # plane stays on the same minor as the workers in nix-sandbox (both
-        # currently 1.36.x); nixos-25.11 lags at 1.34.
+        # Intel NUC: Kubernetes control-plane node (tailscale + kubeadm),
+        # installed from the minimal ISO below.
         nuc = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
-          modules = [
-            ./hosts/nuc/configuration.nix
-            {
-              nixpkgs.overlays = [
-                (final: prev: {
-                  inherit (inputs.nixpkgs-unstable.legacyPackages.${prev.stdenv.hostPlatform.system})
-                    kubernetes cri-tools;
-                })
-              ];
-            }
-          ];
+          modules = [ ./hosts/nuc/configuration.nix kubernetesOverlayModule ];
         };
 
-        # Minimal installer ISO: boot + network + SSH; the real system is
+        # Cheap-VPS kubeadm nodes joining the zen2 cluster over Tailscale.
+        # No home-manager here (heavy to build/fetch on small VPSs); vim is
+        # in environment.systemPackages via modules/k8s-vps.nix.
+        sakura-vps = mkK8sVps ./hosts/sakura-vps/configuration.nix;
+        vultr-vps = mkK8sVps ./hosts/vultr-vps/configuration.nix;
+
+        # Converted in place with nixos-infect (OCI can't boot the custom
+        # installer ISOs), so there is no oci-installer target.
+        oci-vps = mkK8sVps ./hosts/oci-vps/configuration.nix;
+
+        # Minimal installer ISOs: boot + network + SSH; the real system is
         # pulled over the network with nixos-install --flake
         installer = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           modules = [ ./hosts/iso/configuration.nix ];
+        };
+
+        # `make sakura-iso` / `make vultr-iso` build the custom installer
+        # ISOs to upload/mount via each provider's control panel (or, for
+        # Vultr, vultr_iso_private in toof-jp/infra terraform).
+        sakura-installer = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ ./hosts/sakura-vps/installer.nix ];
+        };
+        vultr-installer = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ ./hosts/vultr-vps/installer.nix ];
         };
 
         # StarFive VisionFive 2 (riscv64), cross-built from x86_64.
@@ -143,6 +170,15 @@
       # Installer ISO for physical machines (NUC): nix build .#iso
       packages.x86_64-linux.iso =
         self.nixosConfigurations.installer.config.system.build.isoImage;
+
+      # Provider-specific installer ISOs baked with the SSH key + install
+      # script (and, for Sakura, static networking):
+      #   nix build .#sakura-installer-iso
+      #   nix build .#vultr-installer-iso
+      packages.x86_64-linux.sakura-installer-iso =
+        self.nixosConfigurations.sakura-installer.config.system.build.isoImage;
+      packages.x86_64-linux.vultr-installer-iso =
+        self.nixosConfigurations.vultr-installer.config.system.build.isoImage;
 
       # SD image for the VisionFive 2 (dd it to the card as-is)
       packages.x86_64-linux.visionfive2-image =

--- a/nix/hosts/oci-vps/configuration.nix
+++ b/nix/hosts/oci-vps/configuration.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../modules/k8s-vps.nix
+    ./network.nix
+  ];
+
+  networking.hostName = "oci-vps";
+
+  kubernetesNode.nodeIP = "100.83.17.82";
+
+  # OCI boots UEFI with Ubuntu's stock layout: a 106MB ESP (sda15) that is
+  # far too small for NixOS kernels+initrds, plus a 913MB ext4 /boot
+  # (sda16). Unlike sakura/vultr's BIOS grub on /dev/vda, install GRUB as
+  # the removable EFI loader (OCI NVRAM entries don't survive instance
+  # lifecycle events) and keep kernels on the ext4 /boot.
+  boot.loader.grub = {
+    device = lib.mkForce "nodev";
+    efiSupport = true;
+    efiInstallAsRemovable = true;
+    configurationLimit = 5;
+  };
+  boot.loader.efi.efiSysMountPoint = "/boot/efi";
+
+  # OCI's serial console (console history + interactive console connection)
+  # reads ttyS0; without this the whole boot is invisible when SSH is down.
+  boot.kernelParams = [ "console=ttyS0,115200n8" "console=tty0" ];
+}

--- a/nix/hosts/oci-vps/hardware-configuration.nix
+++ b/nix/hosts/oci-vps/hardware-configuration.nix
@@ -1,0 +1,26 @@
+{ modulesPath, ... }:
+
+# Ubuntu's stock OCI partition layout, kept as-is by nixos-infect:
+# sda1 root, sda15 the (tiny) ESP, sda16 the ext4 /boot that holds
+# kernels and grub.cfg.
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "xen_blkfront" "vmw_pvscsi" ];
+  boot.initrd.kernelModules = [ "nvme" ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-uuid/7b6acfda-4881-4b46-93d8-7f282f6c5548";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-uuid/69ff1a96-45f5-4d0e-adf5-cfa2b537ab41";
+    fsType = "ext4";
+  };
+
+  fileSystems."/boot/efi" = {
+    device = "/dev/disk/by-uuid/683A-3428";
+    fsType = "vfat";
+  };
+}

--- a/nix/hosts/oci-vps/network.nix
+++ b/nix/hosts/oci-vps/network.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+# OCI hands out the private IP over DHCP (public IP is 1:1 NAT at the VCN
+# edge), so DHCP is enough — same shape as vultr-vps.
+{
+  networking.useDHCP = true;
+
+  # kubeadm inherits the cluster-wide kubelet config, which points
+  # resolvConf at /run/systemd/resolve/resolv.conf — that file only
+  # exists when systemd-resolved is running.
+  services.resolved.enable = true;
+
+  # Don't depend on the DHCP -> resolved handoff for global nameservers;
+  # pin resolvers explicitly like the other VPS nodes.
+  networking.nameservers = [ "1.1.1.1" "8.8.8.8" ];
+}

--- a/nix/hosts/sakura-vps/README.md
+++ b/nix/hosts/sakura-vps/README.md
@@ -1,0 +1,149 @@
+# sakura-vps 手動作業ドキュメント
+
+さくらのVPS上の NixOS ノード（zen2 クラスタの control-plane）の構築手順。
+Nix で宣言化されている部分（固定IP、kubelet の `--node-ip`、systemd-resolved など）は
+`make deploy` 系で再現されるが、以下は**手動作業が必要**。
+
+## 構成
+
+| 項目 | 値 |
+|---|---|
+| 公開IP | 153.126.161.157 (/23, GW 153.126.160.1, DHCPなし・固定設定) |
+| tailscale IP | 100.117.158.100 |
+| 役割 | kubeadm control-plane（zen2 クラスタに参加） |
+| SSH | `ssh root@153.126.161.157`（鍵認証のみ） |
+
+## 1. インストーラISOの作成とアップロード
+
+```sh
+nix build ./nix#sakura-installer-iso   # result/iso/nixos-minimal-*.iso ができる
+```
+
+さくらのコントロールパネル → 対象VPS → OS再インストール → ISOイメージインストール で
+SFTPアカウントを発行し、アップロードする:
+
+```sh
+sftp <user>@vps-isoX.sakura.ad.jp
+cd iso
+put result/iso/nixos-minimal-*.iso
+```
+
+- ISOには固定IP設定（`network.nix`）とSSH公開鍵が焼き込み済み。起動すればネットワークは自動で上がる
+- パケットフィルタで TCP 22 が許可されているか確認すること
+- ISO内に焼き込まれる `sakura-install` は `github:toof-jp/dotfiles?dir=nix#sakura-vps`
+  を fetch するので、**ISOビルド前にVPS用の変更を `main` に push しておくこと**。
+  ローカルのみの変更はインストールされない
+
+## 2. OSインストール
+
+コントロールパネルでISOをマウントして起動し、コンソールまたは SSH で:
+
+```sh
+sakura-install   # ISOに焼き込み済みのスクリプト。YES と入力すると実行
+```
+
+やること（スクリプトの中身）: `/dev/vda` を GPT + BIOS boot パーティションで初期化 →
+ext4 (label: nixos) → 一時swap 2GB 作成（closureコピーのOOM対策。本番設定にswapは無い。
+**kubeletはswap有効だと起動しない**ため） → `nixos-install --flake 'github:toof-jp/dotfiles?dir=nix#sakura-vps'`
+
+完了したらコントロールパネルで**ISOのマウントを解除してから** `reboot`。
+
+インストーラのユーザーは `nixos`（パスワード空、sudo可）。rootパスワードも空。
+
+## 3. Tailscale 参加
+
+```sh
+ssh root@153.126.161.157
+tailscale up    # 表示されるURLをブラウザで開いて認証
+tailscale ip -4 # → 100.117.158.100 のはず
+```
+
+IPが変わった場合は `sakura-vps/configuration.nix` の `kubernetesNode.nodeIP` を更新して再デプロイ。
+
+## 4. zen2 クラスタへの control-plane join
+
+### 4.1 zen2 側の前提（対応済み・一度きり）
+
+zen2 のクラスタは元々 LAN IP (192.168.3.2) しか使っていなかったため、
+tailscale 経由で join できるように以下を変更済み。**再インストール時に再実行は不要**だが、
+zen2 を作り直した場合はやり直しになる:
+
+- `etcd.yaml` の `--listen-client-urls` / `--listen-peer-urls` に `100.83.127.53` を追加
+- `--advertise-client-urls` と annotation `kubeadm.kubernetes.io/etcd.advertise-client-urls` を
+  `https://100.83.127.53:2379` **のみ**に変更（kubeadm はリスト先頭しか使わないため、
+  到達不能な LAN IP が先頭にあると join が固まる）
+- `etcdctl member update <zen2-id> --peer-urls=https://100.83.127.53:2380`（同上の理由でtailscaleのみ）
+- etcd server/peer 証明書を SAN `100.83.127.53` 入りで再生成
+  （`kubeadm init phase certs etcd-server|etcd-peer --config <serverCertSANs入りconfig>`）
+- apiserver 証明書を SAN `100.83.127.53` 入りで再生成
+- ClusterConfiguration に `controlPlaneEndpoint: 100.83.127.53:6443` を設定して
+  `kubeadm init phase upload-config kubeadm` でアップロード（未設定だと control-plane join 不可）
+- kube-public の `cluster-info` ConfigMap の server を `https://100.83.127.53:6443` に変更
+  （join はここに書かれたアドレスに接続する）
+
+**注意: `/etc/kubernetes/manifests/` の中にバックアップファイルを置かないこと。**
+kubelet がディレクトリ内の全ファイルをマニフェストとして読むため、同名Podが競合して
+設定変更が反映されなくなる（今回この罠で1時間溶かした）。
+
+### 4.2 join 手順
+
+zen2 で join トークンと証明書キーを発行:
+
+```sh
+sudo kubeadm token create --print-join-command
+sudo kubeadm init phase upload-certs --upload-certs   # certificate key は2時間有効
+```
+
+sakura-vps で（事前に `kubeadm reset -f` してから）:
+
+```sh
+kubeadm join 100.83.127.53:6443 \
+  --token <token> \
+  --discovery-token-ca-cert-hash sha256:<hash> \
+  --control-plane \
+  --certificate-key <certificate-key> \
+  --apiserver-advertise-address=100.117.158.100 \
+  --node-name sakura-vps
+```
+
+- `--apiserver-advertise-address` に tailscale IP を指定するのが重要
+  （これが etcd の advertise / 証明書 SAN にも使われる）
+- `--node-name` を明示するのは、ホスト名衝突事故の予防
+
+### 4.3 join に失敗した場合の掃除
+
+join が途中で失敗すると etcd に未起動の learner メンバーが残り、次の join を妨げる。
+zen2 で確認・削除:
+
+```sh
+sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf exec -n kube-system etcd-zen2 -- \
+  etcdctl --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+          --cert=/etc/kubernetes/pki/etcd/peer.crt \
+          --key=/etc/kubernetes/pki/etcd/peer.key \
+          --endpoints=https://127.0.0.1:2379 member list
+# name が空で isLearner の ID を削除
+sudo kubectl ... member remove <hex-id>
+```
+
+sakura-vps 側は `kubeadm reset -f` してから再 join。
+
+## 5. 運用上の注意
+
+- **etcd は現在2メンバー（zen2 + sakura-vps）。クォーラムは2なので、どちらか片方が
+  落ちるとクラスタ全体が書き込み不能になる。** 3台目の追加を推奨
+- 両ノードとも control-plane taint (`node-role.kubernetes.io/control-plane:NoSchedule`)
+  が付いているため、アプリPodは worker を join させるか taint を外さないと動かない
+- ノード間通信（apiserver / etcd / kubelet）はすべて tailscale (100.x) 経由。
+  tailscale が落ちるとクラスタ通信も止まる
+- swap は意図的に無効（kubelet の制約）。メモリ2GBと少ないので重いworkloadは載せないこと
+
+## トラブルシューティング履歴（原因と対策の索引）
+
+| 症状 | 原因 | 対策 |
+|---|---|---|
+| インストーラがネットに出られない | さくらのVPSはDHCPなし | `network.nix` で固定IP（ISOに焼き込み済み） |
+| `kubeadm init/join` がswapエラー | kubeletはswap非対応 | 本番設定からswap削除済み |
+| Pod sandbox作成失敗 `/run/systemd/resolve/resolv.conf` | クラスタのkubelet設定がsystemd-resolved前提 | `services.resolved.enable = true`（設定済み） |
+| join がetcd接続でタイムアウト | メンバーURL先頭が到達不能なLAN IP | member update / advertise URLをtailscaleのみに |
+| etcd設定変更が反映されない | manifests/内のバックアップファイルが競合 | manifests/にはマニフェスト以外置かない |
+| ノードのINTERNAL-IPが公開IPになる | kubeletのIP自動検出 | `kubernetesNode.nodeIP`で`--node-ip`指定（設定済み） |

--- a/nix/hosts/sakura-vps/configuration.nix
+++ b/nix/hosts/sakura-vps/configuration.nix
@@ -1,0 +1,14 @@
+{ ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../modules/k8s-vps.nix
+    ./network.nix
+    ./nemousu-redirect.nix
+  ];
+
+  networking.hostName = "sakura-vps";
+
+  kubernetesNode.nodeIP = "100.117.158.100";
+}

--- a/nix/hosts/sakura-vps/hardware-configuration.nix
+++ b/nix/hosts/sakura-vps/hardware-configuration.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+# PLACEHOLDER — regenerate this file for real once the VPS has been
+# partitioned. Boot the installer ISO, partition /dev/vda (a single ext4
+# root partition plus a small BIOS-boot partition is enough for GRUB in
+# legacy/BIOS mode), mount it at /mnt, then run:
+#
+#   nixos-generate-config --root /mnt
+#
+# and copy the resulting hardware-configuration.nix over this file before
+# running `nixos-install`.
+
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "virtio_pci" "sd_mod" "sr_mod" ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/nix/hosts/sakura-vps/installer.nix
+++ b/nix/hosts/sakura-vps/installer.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  imports = [
+    ../../modules/vps-installer.nix
+    # Sakura's network has no DHCP, so the live env needs the same static
+    # config as the installed system to be reachable over SSH.
+    ./network.nix
+  ];
+
+  vpsInstaller = {
+    flakeAttr = "sakura-vps";
+    scriptName = "sakura-install";
+    doneMessage = "Unmount the ISO in the Sakura control panel, then reboot.";
+  };
+}

--- a/nix/hosts/sakura-vps/nemousu-redirect.nix
+++ b/nix/hosts/sakura-vps/nemousu-redirect.nix
@@ -1,0 +1,30 @@
+{ ... }:
+
+# Expose the nemousu.live-on.net redirector on the well-known ports.
+# The pod runs as a NodePort Service (30080/30443) in bbs/, because
+# Kubernetes' default --service-node-port-range is 30000-32767 and
+# widening it cluster-wide for one Service isn't worth the blast
+# radius. Caddy still needs :80 for the Let's Encrypt HTTP-01
+# challenge, so we REDIRECT (localhost-DNAT) :80/:443 to the
+# NodePorts in nat PREROUTING; kube-proxy's KUBE-SERVICES jump runs
+# after ours (kube-proxy appends, we insert at position 1) and DNATs
+# further to the pod IP, so the packet leaves via FORWARD — no
+# `allowedTCPPorts` entry needed for :80/:443 or the NodePorts.
+#
+# `ens3` is Sakura's public interface. Bound explicitly so localhost /
+# tailscale traffic to the same ports isn't hijacked.
+{
+  networking.firewall.extraCommands = ''
+    iptables -w -t nat -N nemousu-redirect 2>/dev/null || iptables -w -t nat -F nemousu-redirect
+    iptables -w -t nat -A nemousu-redirect -p tcp --dport 80  -j REDIRECT --to-ports 30080
+    iptables -w -t nat -A nemousu-redirect -p tcp --dport 443 -j REDIRECT --to-ports 30443
+    iptables -w -t nat -C PREROUTING -i ens3 -p tcp -m multiport --dports 80,443 -j nemousu-redirect 2>/dev/null || \
+      iptables -w -t nat -I PREROUTING 1 -i ens3 -p tcp -m multiport --dports 80,443 -j nemousu-redirect
+  '';
+
+  networking.firewall.extraStopCommands = ''
+    iptables -w -t nat -D PREROUTING -i ens3 -p tcp -m multiport --dports 80,443 -j nemousu-redirect 2>/dev/null || true
+    iptables -w -t nat -F nemousu-redirect 2>/dev/null || true
+    iptables -w -t nat -X nemousu-redirect 2>/dev/null || true
+  '';
+}

--- a/nix/hosts/sakura-vps/network.nix
+++ b/nix/hosts/sakura-vps/network.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+
+# Sakura's VPS network has no DHCP — the fixed IP, gateway, and netmask
+# shown in the control panel's server -> network tab must be configured
+# by hand. 255.255.254.0 is a /23.
+{
+  networking.networkmanager.enable = lib.mkForce false;
+  networking.useDHCP = false;
+  networking.interfaces.ens3.ipv4.addresses = [
+    {
+      address = "153.126.161.157";
+      prefixLength = 23;
+    }
+  ];
+  networking.defaultGateway = "153.126.160.1";
+  networking.nameservers = [ "133.242.0.3" "210.188.224.10" ];
+
+  # kubeadm inherits the cluster-wide kubelet config, which points
+  # resolvConf at /run/systemd/resolve/resolv.conf — that file only
+  # exists when systemd-resolved is running, and disabling
+  # NetworkManager above took resolved down with it. Without this every
+  # pod sandbox creation fails with "no such file or directory".
+  services.resolved.enable = true;
+}

--- a/nix/hosts/vultr-vps/configuration.nix
+++ b/nix/hosts/vultr-vps/configuration.nix
@@ -1,0 +1,27 @@
+{ ... }:
+
+{
+  imports = [
+    ./hardware-configuration.nix
+    ../../modules/k8s-vps.nix
+    ./network.nix
+  ];
+
+  networking.hostName = "vultr-vps";
+
+  kubernetesNode.nodeIP = "100.71.128.99";
+
+  # kube-apiserver alone takes ~1.8GiB on this 4GB control-plane, pushing
+  # node memory to ~80%. Under that pressure every probe on the node times
+  # out simultaneously (apiserver readiness 500, longhorn-manager/csi/engine
+  # probe timeouts, node-exporter restarts every ~14min). Reservations keep
+  # kubelet, containerd, sshd, tailscaled in their own cgroup so they don't
+  # stall; eviction trips before the OS starts reclaiming from system procs.
+  # eviction-minimum-reclaim avoids per-cycle micro-reclaim thrash.
+  kubernetesNode.extraKubeletArgs = [
+    "--system-reserved=cpu=100m,memory=300Mi"
+    "--kube-reserved=cpu=100m,memory=300Mi"
+    "--eviction-hard=memory.available<300Mi,nodefs.available<10%"
+    "--eviction-minimum-reclaim=memory.available=100Mi,nodefs.available=5%"
+  ];
+}

--- a/nix/hosts/vultr-vps/hardware-configuration.nix
+++ b/nix/hosts/vultr-vps/hardware-configuration.nix
@@ -1,0 +1,30 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+# PLACEHOLDER — regenerate this file for real once the VPS has been
+# partitioned. Boot the installer ISO, run `vultr-install` (which
+# partitions /dev/vda: a small BIOS-boot partition plus a single ext4
+# root), then run:
+#
+#   nixos-generate-config --root /mnt
+#
+# and copy the resulting hardware-configuration.nix over this file before
+# the final `nixos-install` (vultr-install does the install directly from
+# the flake, so in practice: install once, regenerate, commit, rebuild).
+
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+  boot.initrd.availableKernelModules = [ "ata_piix" "uhci_hcd" "virtio_pci" "sd_mod" "sr_mod" ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/nix/hosts/vultr-vps/installer.nix
+++ b/nix/hosts/vultr-vps/installer.nix
@@ -1,0 +1,13 @@
+{ ... }:
+
+{
+  # Vultr's network is DHCP, which the minimal installer profile already
+  # enables — no static network module needed here (cf. sakura-vps).
+  imports = [ ../../modules/vps-installer.nix ];
+
+  vpsInstaller = {
+    flakeAttr = "vultr-vps";
+    scriptName = "vultr-install";
+    doneMessage = "Detach the ISO (vultr_attach_iso = false in toof-jp/infra terraform), then reboot.";
+  };
+}

--- a/nix/hosts/vultr-vps/network.nix
+++ b/nix/hosts/vultr-vps/network.nix
@@ -1,0 +1,19 @@
+{ ... }:
+
+# Unlike Sakura, Vultr hands out the public IPv4 over DHCP, so no static
+# addressing is needed.
+{
+  networking.useDHCP = true;
+
+  # kubeadm inherits the cluster-wide kubelet config, which points
+  # resolvConf at /run/systemd/resolve/resolv.conf — that file only
+  # exists when systemd-resolved is running. Without this every pod
+  # sandbox creation fails with "no such file or directory".
+  services.resolved.enable = true;
+
+  # The dhcpcd -> resolved handoff left resolved with zero global
+  # nameservers, so /run/systemd/resolve/resolv.conf was empty and
+  # coredns on this node crashlooped with "plugin/forward: no
+  # nameservers found". Pin resolvers explicitly like sakura-vps does.
+  networking.nameservers = [ "1.1.1.1" "8.8.8.8" ];
+}

--- a/nix/modules/k8s-vps.nix
+++ b/nix/modules/k8s-vps.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+# Shared config for cheap-VPS k8s nodes (sakura-vps, vultr-vps, oci-vps).
+# Host-specific bits stay in each host dir: hostname, kubernetesNode.nodeIP,
+# network.nix, hardware-configuration.nix.
+{
+  imports = [ ./kubernetes-node.nix ];
+
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [ "claude-code" "codex" ];
+
+  # Sakura and Vultr boot in legacy BIOS mode with a single virtio disk, so
+  # a BIOS-boot partition plus GRUB on /dev/vda is enough — no EFI/ESP
+  # needed. oci-vps overrides this (Ubuntu ESP + ext4 /boot from
+  # nixos-infect) in its own configuration.nix.
+  boot.loader.grub.enable = true;
+  boot.loader.grub.device = "/dev/vda";
+
+  networking.firewall.enable = true;
+  networking.firewall.allowedTCPPorts = [ 22 ];
+
+  # No persistent swap: kubelet refuses to start with swap on unless it's
+  # explicitly configured for cgroup v2 (NodeSwap feature gate +
+  # memorySwap.swapBehavior), which we don't set up. The temporary
+  # swapfile created by the installer script before `nixos-install` (to
+  # avoid OOM while building/copying the closure) is only used during
+  # install and isn't declared here, so it's gone on first boot of this
+  # config.
+  swapDevices = [ ];
+
+  environment.systemPackages = with pkgs; [ vim git tmux wget htop ];
+
+  # Longhorn stores replicas on this node (/var/lib/longhorn). Its v1 data
+  # engine attaches volumes over iSCSI, so iscsid must run on the host.
+  services.openiscsi = {
+    enable = true;
+    name = "iqn.2016-04.com.open-iscsi:${config.networking.hostName}";
+  };
+  # longhorn-manager nsenters the host mount namespace and invokes iscsiadm
+  # etc. by absolute-ish PATH lookup (/usr/local/bin, /usr/bin, ...), none of
+  # which exist on NixOS — expose the system profile there.
+  systemd.tmpfiles.rules = [
+    "L+ /usr/local/bin - - - - /run/current-system/sw/bin/"
+  ];
+
+  system.stateVersion = "26.05";
+
+  services.openssh.enable = true;
+  services.openssh.settings.PermitRootLogin = "prohibit-password";
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
+  ];
+
+  programs.zsh.enable = true;
+  users.users.root.shell = pkgs.zsh;
+}

--- a/nix/modules/kubernetes-node.nix
+++ b/nix/modules/kubernetes-node.nix
@@ -1,0 +1,80 @@
+{ pkgs, lib, config, ... }:
+
+{
+  options.kubernetesNode.nodeIP = lib.mkOption {
+    type = lib.types.str;
+    description = ''
+      Tailscale IP this node's kubelet advertises as its InternalIP, so
+      cluster traffic (apiserver, kubelet, kube-proxy) flows over the
+      tailscale mesh instead of whatever the kernel picks as the default
+      route (usually the public interface).
+    '';
+  };
+
+  # Reservations, eviction thresholds and other memory-sensitive flags
+  # differ between the 4GB VPSs and the 1GB oci-vps, so keep them out
+  # of this shared module and let each host add its own.
+  options.kubernetesNode.extraKubeletArgs = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = "Extra CLI flags appended to the kubelet ExecStart.";
+  };
+
+  config = {
+    boot.kernelModules = [ "overlay" "br_netfilter" ];
+    boot.kernel.sysctl = {
+      "net.ipv4.ip_forward" = 1;
+      "net.bridge.bridge-nf-call-iptables" = 1;
+      "net.bridge.bridge-nf-call-ip6tables" = 1;
+    };
+
+    virtualisation.containerd.enable = true;
+    virtualisation.containerd.settings.plugins."io.containerd.grpc.v1.cri".cni.bin_dir = "/opt/cni/bin";
+
+    system.activationScripts.cniPlugins = ''
+      mkdir -p /opt/cni/bin
+      for f in ${pkgs.cni-plugins}/bin/*; do
+        ln -sf "$f" /opt/cni/bin/
+      done
+    '';
+
+    environment.systemPackages = [ pkgs.kubernetes pkgs.cri-tools ];
+
+    # kubeadm (init or join) writes bootstrap-kubelet.conf and
+    # /var/lib/kubelet/config.yaml, then expects a kubelet systemd unit to
+    # already exist so it can `systemctl restart kubelet`. NixOS has no
+    # distro package for that unit, so it is declared here for both the
+    # control-plane and worker roles.
+    systemd.services.kubelet = {
+      description = "Kubernetes Kubelet";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "containerd.service" ];
+      path = [ pkgs.kubernetes pkgs.iproute2 pkgs.ethtool pkgs.socat pkgs.conntrack-tools pkgs.util-linux ];
+      serviceConfig = {
+        ExecStart = lib.concatStringsSep " " ([
+          "${pkgs.kubernetes}/bin/kubelet"
+          "--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf"
+          "--kubeconfig=/etc/kubernetes/kubelet.conf"
+          "--config=/var/lib/kubelet/config.yaml"
+          "--container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+          "--node-ip=${config.kubernetesNode.nodeIP}"
+        ] ++ config.kubernetesNode.extraKubeletArgs);
+        Restart = "always";
+        StartLimitIntervalSec = 0;
+      };
+    };
+
+    # Node-to-node traffic (kubeadm join/init, apiserver, etcd, kubelet,
+    # kube-proxy) all flow over the tailscale mesh instead of the public
+    # internet. Interfaces trusted below only matter on hosts that also
+    # enable the firewall. flannel.1/cni0 must be trusted too: pod ->
+    # ClusterIP service traffic (e.g. CoreDNS -> kube-apiserver) is
+    # DNAT'd by kube-proxy to the node's own address and arrives on
+    # INPUT from those interfaces, not tailscale0 — without this,
+    # CoreDNS can never reach the apiserver on a host with the firewall
+    # enabled.
+    services.tailscale.enable = true;
+    services.tailscale.openFirewall = true;
+    networking.firewall.trustedInterfaces = [ "tailscale0" "flannel.1" "cni0" ];
+  };
+}

--- a/nix/modules/vps-installer.nix
+++ b/nix/modules/vps-installer.nix
@@ -1,0 +1,79 @@
+{ modulesPath, pkgs, lib, config, ... }:
+
+# Shared installer-ISO module for the VPS hosts. Each host's installer.nix
+# imports this, sets vpsInstaller.*, and adds host-specific networking if
+# the provider has no DHCP (Sakura).
+let
+  cfg = config.vpsInstaller;
+
+  installScript = pkgs.writeShellScriptBin cfg.scriptName ''
+    set -euo pipefail
+
+    if [ "$(id -u)" -ne 0 ]; then
+      exec sudo "$0" "$@"
+    fi
+
+    echo "This will ERASE /dev/vda and install NixOS (${cfg.flakeAttr}). Type YES to continue:"
+    read -r confirm
+    if [ "$confirm" != "YES" ]; then
+      echo "Aborted."
+      exit 1
+    fi
+
+    parted /dev/vda -- mklabel gpt
+    parted /dev/vda -- mkpart primary 1MiB 2MiB
+    parted /dev/vda -- set 1 bios_grub on
+    parted /dev/vda -- mkpart primary ext4 2MiB 100%
+    mkfs.ext4 -L nixos /dev/vda2
+    # mkfs and the by-label symlink race: udev may not have processed the
+    # new label yet when mount runs (seen on Vultr: "Can't lookup blockdev").
+    udevadm settle
+    mount /dev/disk/by-label/nixos /mnt
+
+    mkdir -p /mnt/var/lib
+    dd if=/dev/zero of=/mnt/var/lib/swapfile bs=1M count=2048
+    chmod 600 /mnt/var/lib/swapfile
+    mkswap /mnt/var/lib/swapfile
+    swapon /mnt/var/lib/swapfile
+
+    NIX_CONFIG="experimental-features = nix-command flakes" \
+      nixos-install --root /mnt --flake 'github:toof-jp/dotfiles?dir=nix#${cfg.flakeAttr}' --no-root-passwd
+
+    echo "Done. ${cfg.doneMessage}"
+  '';
+in
+{
+  options.vpsInstaller = {
+    flakeAttr = lib.mkOption {
+      type = lib.types.str;
+      description = "nixosConfigurations attribute that nixos-install targets.";
+    };
+    scriptName = lib.mkOption {
+      type = lib.types.str;
+      description = "Name of the install command available in the live env.";
+    };
+    doneMessage = lib.mkOption {
+      type = lib.types.str;
+      default = "Detach the ISO, then reboot.";
+      description = "Provider-specific instruction printed after install.";
+    };
+  };
+
+  imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix" ];
+
+  config = {
+    # The installer profile ships ZFS support, which warns unless this is
+    # set explicitly. The live env never imports a ZFS root, so opt into
+    # the safer future default now.
+    boot.zfs.forceImportRoot = false;
+
+    # The default installer profile already enables sshd (PermitRootLogin
+    # "yes") and root has no password — so nothing logs in until a key is
+    # added here.
+    users.users.root.openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIN8H2c3Qa2EsEh6RQG6nRoRFblH8fj5dHj9YyVD9tND toof@toof.jp"
+    ];
+
+    environment.systemPackages = with pkgs; [ git vim wget tmux installScript ];
+  };
+}


### PR DESCRIPTION
## Summary

- Bring `sakura-vps`, `vultr-vps`, and `oci-vps` (plus the sakura/vultr installer ISOs) into `nix/flake.nix` so every NixOS host lives in one place. `github.com/toof-jp/nix-sandbox` can be archived after this lands.
- Shared modules under `nix/modules/` (`k8s-vps.nix`, `kubernetes-node.nix`, `vps-installer.nix`); per-host bits under `nix/hosts/<host>/`.
- New `kubernetesOverlayModule` pins `kubernetes` / `cri-tools` to nixpkgs-unstable and is applied to `nuc` and every VPS, so all kubeadm hosts stay on the same 1.36.x minor while the dotfiles flake continues to track `nixos-25.11` (nix-sandbox was on `nixos-26.05`, which shipped k8s 1.36).
- Installer scripts baked into the sakura/vultr ISOs now `nixos-install --flake 'github:toof-jp/dotfiles?dir=nix#<host>'` instead of pulling from nix-sandbox.
- New package outputs: `.#sakura-installer-iso`, `.#vultr-installer-iso`.

## Test plan

- [x] `nix flake check --no-build ./nix` — all 11 nixosConfigurations + 5 packages evaluate cleanly
- [ ] `nix build ./nix#sakura-installer-iso` (fetch/build the ISO)
- [ ] `nix build ./nix#vultr-installer-iso` (fetch/build the ISO)
- [ ] After merge, `sudo nixos-rebuild switch --flake 'github:toof-jp/dotfiles?dir=nix#sakura-vps'` (and similarly for vultr / oci) from each VPS to confirm the rebuild path

## Follow-ups (out of scope for this PR)

- Archive `toof-jp/nix-sandbox` once these configs are proven from dotfiles (planned via `github-repository-terraform`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)