### PR TITLE
feat(nix): add fumiya_tokumasu@mac home config

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -73,14 +73,14 @@
       ];
 
       # Standalone home-manager (macOS and non-NixOS Linux)
-      mkHome = { system, homeDirectory, extraModules ? [ ] }:
+      mkHome = { system, homeDirectory, homeUsername ? username, extraModules ? [ ] }:
         home-manager.lib.homeManagerConfiguration {
           pkgs = mkPkgs system;
           extraSpecialArgs = { inherit inputs; };
           modules = [
             ./home/home.nix
             {
-              home.username = username;
+              home.username = homeUsername;
               home.homeDirectory = homeDirectory;
             }
           ] ++ extraModules;
@@ -199,6 +199,16 @@
             # session vars / XDG integration for distros other than NixOS
             { targets.genericLinux.enable = true; }
           ];
+        };
+
+        # Work Mac (Apple Silicon): same person, different local account name
+        # (fumiya_tokumasu instead of toof), so home.username/homeDirectory
+        # are overridden instead of reusing the toof@mac defaults.
+        # nix run home-manager -- switch --flake .#fumiya_tokumasu@mac
+        "fumiya_tokumasu@mac" = mkHome {
+          system = "aarch64-darwin";
+          homeUsername = "fumiya_tokumasu";
+          homeDirectory = "/Users/fumiya_tokumasu";
         };
       };
     };

--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -4,6 +4,8 @@ All commits must be GPG-signed. Never commit with signing disabled (e.g. `--no-g
 
 Before creating any commit, always have the staged changes reviewed by opencode first (e.g. `git diff --staged | opencode run "Review this diff and point out any problems"`). Address the issues it finds (or report them to the user) before committing.
 
+**Exception:** On macOS (Darwin), skip the opencode review step entirely.
+
 # Merge / push policy
 
 Never merge a pull request (via `gh pr merge`, `gh api`, the merge button, or any other means) without the user's explicit approval. Never push directly to `main` — always create a branch and open a pull request instead.


### PR DESCRIPTION
## Summary
- Add a dedicated home-manager configuration `fumiya_tokumasu@mac` for the work Mac (Apple Silicon), overriding `home.username`/`home.homeDirectory` since the local account name differs from the personal `toof@mac` config
- Exempt macOS (Darwin) from the opencode pre-commit review requirement in the deployed CLAUDE.md

## Test plan
- [x] `nix run home-manager -- switch --flake .#fumiya_tokumasu@mac` activates successfully on the work Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)