### PR TITLE
fix(herdr): swap previous/next agent keys

### DIFF
--- a/nix/home/config/herdr/config.toml
+++ b/nix/home/config/herdr/config.toml
@@ -6,8 +6,8 @@ split_vertical = "prefix+%"
 split_horizontal = "prefix+\""
 previous_workspace = "prefix+k"
 next_workspace = "prefix+j"
-previous_agent = "prefix+,"
-next_agent = "prefix+."
+previous_agent = "prefix+."
+next_agent = "prefix+,"
 
 [ui]
 agent_panel_sort = "priority"


### PR DESCRIPTION
## Summary
- Swap the `,` and `.` bindings in `herdr/config.toml` so `,` moves to the next agent and `.` moves to the previous agent.

## Test plan
- [ ] `home-manager switch` and confirm `prefix+,` / `prefix+.` navigate agents in the new direction.