### PR TITLE
chore(nix): bump nixpkgs-unstable so nuc rebuilds off latest rev

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -145,11 +145,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

nuc が古い generation で起動していたため、`nixpkgs-unstable` の pin をリフレッシュして次の `sudo nixos-rebuild switch --refresh` で最新に追従できるようにする。

- `nixpkgs-unstable`: `61b7c44c` (2026-07-18) → `e2587cae` (2026-07-23)
- kubernetes は 1.36.2 のまま（upstream 1.36.3 は nixpkgs `master` には来ているが `nixos-unstable` ブランチにはまだ到達していない）
- ローカルで `nix build .#nixosConfigurations.nuc.config.system.build.toplevel` は成功済み

## 適用手順

nuc 上で以下:

```
sudo nixos-rebuild switch --refresh --flake /etc/nixos#nuc
```

## Test plan

- [ ] nuc 上で `nixos-rebuild switch --refresh` が成功する
- [ ] `kubelet.service` が healthy を維持し、`kubectl get nodes` で Ready
- [ ] kubelet 引数 (`kubeadm-flags.env`) が最新 minor と齟齬なし