### PR TITLE
feat: sign commits with Secretive SSH key

### DIFF
--- a/.config/git/allowed_signers
+++ b/.config/git/allowed_signers
@@ -1,0 +1,1 @@
+../../nix/home/config/git/allowed_signers

--- a/.ssh/config.mac
+++ b/.ssh/config.mac
@@ -1,5 +1,9 @@
+Host *
+  IdentityAgent /Users/toof/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
+
 Host linux zen2
   HostName zen2
+  # Forward the Secretive agent so git can sign with the enclave key on zen2
+  ForwardAgent /Users/toof/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh
   RemoteForward /run/user/1000/gnupg/S.gpg-agent /Users/toof/.gnupg/S.gpg-agent
   StreamLocalBindUnlink yes
-

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ git:
 	mkdir -p ${HOME}/.config/git
 	ln -sf ${PWD}/.config/git/config ${HOME}/.config/git
 	ln -sf ${PWD}/.config/git/ignore ${HOME}/.config/git
+	ln -sf ${PWD}/.config/git/allowed_signers ${HOME}/.config/git
 
 # optional
 gpg: git

--- a/nix/home/config/git/allowed_signers
+++ b/nix/home/config/git/allowed_signers
@@ -1,0 +1,1 @@
+toof@toof.jp ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNkKotxXrjk86I7DxMDmpozCND0mKCUNG+NGdzZUTufpFIfNCMaHWznu3DQ8aCJ4vGs5Z9TkXDd6XpQYkNp/wRQ= toof@toof.jp

--- a/nix/home/config/git/config
+++ b/nix/home/config/git/config
@@ -6,7 +6,15 @@
 [user]
   name = Fumiya Tokumasu
   email = toof@toof.jp
-  signingkey = 1D55316F12B1EF61
+  # Secretive (Secure Enclave) key; the literal pubkey (not a file path) so
+  # signing also works on remote hosts over agent forwarding.
+  signingkey = key::ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNkKotxXrjk86I7DxMDmpozCND0mKCUNG+NGdzZUTufpFIfNCMaHWznu3DQ8aCJ4vGs5Z9TkXDd6XpQYkNp/wRQ= toof@toof.jp
+
+[gpg]
+  format = ssh
+
+[gpg "ssh"]
+  allowedSignersFile = ~/.config/git/allowed_signers
 
 [push]
   autoSetupRemote = true

--- a/nix/home/configs.nix
+++ b/nix/home/configs.nix
@@ -11,6 +11,7 @@
     # extra GPG bits remain per-machine opt-in; git ignores a missing include.
     "git/config".source = ./config/git/config;
     "git/ignore".source = ./config/git/ignore;
+    "git/allowed_signers".source = ./config/git/allowed_signers;
 
     "rustfmt".source = ./config/rustfmt;
 

--- a/nix/home/zshrc
+++ b/nix/home/zshrc
@@ -179,27 +179,37 @@ function demosh() {
 }
 demosh
 
-env=~/.ssh/agent.env
+# SSH agent
+# - macOS: use Secretive's Secure Enclave agent (also what git ssh signing uses)
+# - inside an SSH session: keep the forwarded agent from the client
+# - otherwise: fall back to a personal ssh-agent via ~/.ssh/agent.env
+SECRETIVE_SOCK="$HOME/Library/Containers/com.maxgoedjen.Secretive.SecretAgent/Data/socket.ssh"
+if [ -S "$SECRETIVE_SOCK" ]; then
+    export SSH_AUTH_SOCK="$SECRETIVE_SOCK"
+elif [ -z "$SSH_CONNECTION" ]; then
+    env=~/.ssh/agent.env
 
-agent_load_env () { test -f "$env" && . "$env" >| /dev/null ; }
+    agent_load_env () { test -f "$env" && . "$env" >| /dev/null ; }
 
-agent_start () {
-    (umask 077; ssh-agent >| "$env")
-    . "$env" >| /dev/null ; }
+    agent_start () {
+        (umask 077; ssh-agent >| "$env")
+        . "$env" >| /dev/null ; }
 
-agent_load_env
+    agent_load_env
 
-# agent_run_state: 0=agent running w/ key; 1=agent w/o key; 2=agent not running
-agent_run_state=$(ssh-add -l >| /dev/null 2>&1; echo $?)
+    # agent_run_state: 0=agent running w/ key; 1=agent w/o key; 2=agent not running
+    agent_run_state=$(ssh-add -l >| /dev/null 2>&1; echo $?)
 
-if [ ! "$SSH_AUTH_SOCK" ] || [ $agent_run_state = 2 ]; then
-    agent_start
-    ssh-add
-elif [ "$SSH_AUTH_SOCK" ] && [ $agent_run_state = 1 ]; then
-    ssh-add
+    if [ ! "$SSH_AUTH_SOCK" ] || [ $agent_run_state = 2 ]; then
+        agent_start
+        ssh-add
+    elif [ "$SSH_AUTH_SOCK" ] && [ $agent_run_state = 1 ]; then
+        ssh-add
+    fi
+
+    unset env
 fi
-
-unset env
+unset SECRETIVE_SOCK
 
 # GPG
 export GPG_TTY=$(tty)


### PR DESCRIPTION
## Summary
- Switch git commit signing from GPG to SSH using the Secure Enclave key held by [Secretive](https://github.com/maxgoedjen/secretive)
- `user.signingkey` is the literal public key (`key::...`), not a file path, so signing also works on remote hosts where the private key doesn't exist
- Forward the Secretive agent to zen2 (`ForwardAgent <socket>`) so commits there sign with the same enclave key
- Add `allowed_signers` for signature verification, wired via configs.nix / Makefile / repo-root symlink
- zshrc: point `SSH_AUTH_SOCK` at the Secretive socket on macOS, keep the forwarded agent inside SSH sessions (the `agent.env` block used to clobber it, breaking signing on zen2), fall back to the personal ssh-agent elsewhere

## Test plan
- [x] mac: `git commit` → `git log --show-signature` shows Good signature with the Secretive ECDSA key
- [x] zen2: forwarded agent lists the Secretive key; test commit signs successfully over the forwarded agent
- [ ] zen2: pull + rebuild to deploy the new git config / allowed_signers / zshrc

🤖 Generated with [Claude Code](https://claude.com/claude-code)