### PR TITLE
docs(claude): require SSH signing for commits

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Commit policy
 
-All commits must be GPG-signed. Never commit with signing disabled (e.g. `--no-gpg-sign` or `commit.gpgsign=false`) — if signing fails, stop and report the error instead of working around it.
+All commits must be signed with the SSH (Secretive) key. Never commit with signing disabled (e.g. `--no-gpg-sign` or `commit.gpgsign=false`) — if signing fails, stop and report the error instead of working around it (this usually means the Secretive agent is not reachable, e.g. no agent forwarding on a remote host).
 
 Before creating any commit, always have the staged changes reviewed by opencode first (e.g. `git diff --staged | opencode run "Review this diff and point out any problems"`). Address the issues it finds (or report them to the user) before committing.
 


### PR DESCRIPTION
## Summary
- Update the commit policy in `nix/home/config/claude/CLAUDE.md` (the source of `~/.claude/CLAUDE.md`) from "GPG-signed" to "signed with the SSH (Secretive) key".
- Reflects the switch to Secretive Secure Enclave signing done in 86bfe15.
- Mentions the common failure mode (Secretive agent not reachable — e.g. no agent forwarding) so future-me knows what to check when signing fails.

## Test plan
- [x] `git commit` in a fresh worktree signs successfully with the forwarded Secretive agent (`git log -1 --show-signature` → `Good "git" signature ... ECDSA key`).
- [x] Verified `nix/home/config/git/config` already has `gpg.format=ssh` + Secretive signingkey (from 86bfe15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)