### PR TITLE
docs+feat(claude): switch to code-review plugin (with install config)

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -2,9 +2,7 @@
 
 All commits must be GPG-signed. Never commit with signing disabled (e.g. `--no-gpg-sign` or `commit.gpgsign=false`) — if signing fails, stop and report the error instead of working around it.
 
-Before creating any commit, always have the staged changes reviewed by opencode first (e.g. `git diff --staged | opencode run "Review this diff and point out any problems"`). Address the issues it finds (or report them to the user) before committing.
-
-**Exception:** On macOS (Darwin), skip the opencode review step entirely.
+Before creating any commit, always have the staged changes reviewed by the `code-review@claude-plugins-official` plugin first. Address the issues it finds (or report them to the user) before committing.
 
 # Merge / push policy
 

--- a/nix/home/config/claude/settings.json
+++ b/nix/home/config/claude/settings.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "skipDangerousModePermissionPrompt": true,
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true
+  },
   "permissions": {
     "defaultMode": "auto",
     "allow": [


### PR DESCRIPTION
## Summary
- **Doc:** Swap the pre-commit review step in `~/.claude/CLAUDE.md` from `opencode run` to the `code-review@claude-plugins-official` Claude Code plugin. Drop the macOS exception since the plugin works on both platforms.
- **Config:** Add `extraKnownMarketplaces` + `enabledPlugins` in `nix/home/config/claude/settings.json` so `anthropics/claude-plugins-official` is auto-registered and the `code-review` plugin is enabled on any machine that symlinks this file.

## Caveat — worth reviewing before merge
The `code-review` plugin's `/code-review` command operates on **an already-opened pull request** (posts a comment on the PR), not on a local `git diff --staged` before commit. This is a different flow from what `opencode run` was doing.

If the intent is to keep a **pre-commit** review step, the plugin isn't a drop-in replacement — we'd need a different tool or a different policy (e.g. move the review from pre-commit to post-PR-creation).

## Test plan
- [x] `git log -1 --show-signature` on each commit → `Good "git" signature ... ECDSA key`.
- [x] `jq . nix/home/config/claude/settings.json` parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)