### PR TITLE
docs(claude): make "pull main first" a leading step

### DIFF
--- a/nix/home/config/claude/CLAUDE.md
+++ b/nix/home/config/claude/CLAUDE.md
@@ -37,9 +37,10 @@ When a repository needs CI that builds Docker images and pushes them to ghcr.io,
 
 # Worktree management
 
-Always start new work by creating a worktree with `git gtr new` first, then work inside it — never work directly in the main checkout.
+Every new task starts with two steps, in this order:
 
-Before creating a worktree, update `main` in the main checkout first (e.g. `git pull --ff-only` on `main`) so the new worktree branches off the latest `main`.
+1. In the main checkout, run `git switch main && git pull --ff-only` so the next worktree branches off the latest `main`.
+2. Run `git gtr new <branch>` to create a worktree, and work inside it — never work directly in the main checkout.
 
 Use `git gtr` (git-worktree-runner) to create git worktrees instead of `git worktree add`.
 


### PR DESCRIPTION
## Summary
- Restructure the `# Worktree management` section so the two-step start-of-work workflow (**pull `main`, then create worktree**) is the leading rule, not a follow-up note.
- Switch to `main` explicitly before pulling (`git switch main && git pull --ff-only`) so the pull can't accidentally hit whichever branch was checked out.

## Notes
- The rule already existed but as a secondary bullet; this PR just promotes it and tightens the command.
- Pre-commit review was done informally with `opencode run` (the newly-adopted `code-review@claude-plugins-official` plugin only runs against an already-opened PR, so it can't be used pre-commit — that policy gap from #63 still stands).

## Test plan
- [x] `git log -1 --show-signature` → `Good "git" signature ... ECDSA key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)