### PR TITLE
chore(nix): update flake inputs

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -45,11 +45,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1784144455,
-        "narHash": "sha256-MjK/E0mzJTkoKlzTwVi+lq5z48oYWAwu3j+eDDcPrTE=",
+        "lastModified": 1785788257,
+        "narHash": "sha256-0TQIDj3o3sVI8xh4igj0a56k4boe6zxClRG+rXZuOkE=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "8877eaa80cdffc89c8526e4ad06db21a445202c6",
+        "rev": "35be08cd953e057927c66dc2ad255df459810446",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784310968,
-        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
+        "lastModified": 1785232496,
+        "narHash": "sha256-65EQYIRRpTdpH8lUiB6Mvo5uBkG60aBIzAJuALfx+O0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
+        "rev": "2e790b0a6be8ec2b76174ac0931b8ff11919ec98",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785692966,
+        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Routine `nix flake update` — three inputs advanced by a couple weeks each:
- `herdr`: 2026-07-15 → 2026-08-03
- `nixos-hardware`: 2026-07-17 → 2026-07-28
- `nixpkgs-unstable`: 2026-07-23 → 2026-08-02

`nixpkgs` (release-25.11) was already current.

## Test plan
- [x] `nix flake check ./nix` passes (all NixOS/home configs and image derivations evaluate cleanly).
- [ ] `nix run home-manager -- switch --flake ./nix#toof@linux` on zen2 after merge.

## Notes
- Pre-commit review was skipped: `opencode run` hung on an external-directory permission prompt for `/tmp`, and the `code-review@claude-plugins-official` plugin only operates post-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)