### PR TITLE
feat: add font-family settings to ghostty config

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,0 +1,11 @@
+# Ghostty Configuration
+
+font-family = JetBrains Mono
+font-family = Hiragino Sans
+
+# Note: To open SSH in new window, run this command:
+# open -na Ghostty.app --args -e ssh zen2
+#
+# You can also use macOS Shortcuts app or Karabiner-Elements
+# to bind Cmd+Opt+S to run the shell script at:
+# ~/.config/ghostty/ssh-zen2.sh


### PR DESCRIPTION
## Summary
- Add `font-family` settings (JetBrains Mono + Hiragino Sans fallback) to the Ghostty config
- This also adds `.config/ghostty/config` to the repo for the first time (it was previously untracked; `~/.config/ghostty/config` is already symlinked to it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)